### PR TITLE
chore: refactor DTOs

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -33,7 +33,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/UserDTO'
+                            $ref: '#/components/schemas/UserEditableDto'
             responses:
                 '200':
                     description: Returns the created user.
@@ -85,6 +85,13 @@ paths:
                       type: integer
                   required: true
                   description: Numeric ID of a user
+            requestBody:
+                description: User edit data body.
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/UserEditableDto'
             responses:
                 '200':
                     description: Returns the updated user.
@@ -179,7 +186,7 @@ components:
                 updatedAt:
                     type: string
                     format: date-time
-        UserDTO:
+        UserEditableDto:
             type: object
             properties:
                 name:

--- a/src/Common/ErrorMessage.php
+++ b/src/Common/ErrorMessage.php
@@ -2,7 +2,7 @@
 
 namespace App\Common;
 
-use App\DTO\ErrorDTO;
+use App\Dto\ErrorDto;
 use Exception;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -17,7 +17,7 @@ class ErrorMessage {
      * @return string
      */
     public static function generate(Exception $error, SerializerInterface $serializer): string {
-        $errorDTO = new ErrorDTO($error);
+        $errorDTO = new ErrorDto($error);
         return $serializer->serialize($errorDTO, JsonEncoder::FORMAT);
     }
 }

--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -3,7 +3,7 @@
 namespace App\Controller;
 
 use App\Common\ErrorMessage;
-use App\DTO\UserDTO;
+use App\Dto\UserEditableDto;
 use App\Exception\InvalidRequestException;
 use App\Exception\UserNotFoundException;
 use App\Service\UserServiceInterface;
@@ -155,7 +155,7 @@ class UserController extends AbstractController
     public function createUser(Request $request, SerializerInterface $serializer): Response
     {
         try {
-            $userCreate = $serializer->deserialize($request->getContent(), UserDTO::class, JsonEncoder::FORMAT);
+            $userCreate = $serializer->deserialize($request->getContent(), UserEditableDto::class, JsonEncoder::FORMAT);
         } catch (\Exception $e) {
             error_log($e);
             return new Response(self::INVALID_JSON_FORMAT, Response::HTTP_BAD_REQUEST);
@@ -193,7 +193,7 @@ class UserController extends AbstractController
     public function updateUser(int $userId, Request $request, SerializerInterface $serializer): Response
     {
         try {
-            $userCreate = $serializer->deserialize($request->getContent(), UserDTO::class, JsonEncoder::FORMAT);
+            $userCreate = $serializer->deserialize($request->getContent(), UserEditableDto::class, JsonEncoder::FORMAT);
         } catch (\Exception $e) {
             error_log($e);
 

--- a/src/Dto/ErrorDto.php
+++ b/src/Dto/ErrorDto.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace App\DTO;
+namespace App\Dto;
 
 /**
- * ErrorDTO holds basic error data.
+ * ErrorDto holds basic error data.
  */
-class ErrorDTO
+class ErrorDto
 {
     /**
      * @var string

--- a/src/Dto/UserEditableDto.php
+++ b/src/Dto/UserEditableDto.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace App\DTO;
+namespace App\Dto;
 
 /**
- * UserDTO holds editable attributes for creating/updating a user.
+ * UserEditableDto holds editable attributes for creating/updating a user.
  */
-class UserDTO
+class UserEditableDto
 {
     /**
      * @var string|null

--- a/src/Service/UserService.php
+++ b/src/Service/UserService.php
@@ -2,7 +2,7 @@
 
 namespace App\Service;
 
-use App\DTO\UserDTO;
+use App\Dto\UserEditableDto;
 use App\Entity\User;
 use App\Exception\InvalidRequestException;
 use App\Exception\UserNotFoundException;
@@ -80,11 +80,11 @@ class UserService implements UserServiceInterface {
     }
 
     /**
-     * @param \App\DTO\UserDTO $userCreate
+     * @param \App\Dto\UserEditableDto $userCreate
      * @return User
      * @throws InvalidRequestException
      */
-    public function createUser(UserDTO $userCreate): User {
+    public function createUser(UserEditableDto $userCreate): User {
         if($userCreate->getName() == "") {
             throw new InvalidRequestException(self::ERROR_EMPTY_USER_NAME);
         }
@@ -107,12 +107,12 @@ class UserService implements UserServiceInterface {
 
     /**
      * @param int $userId
-     * @param \App\DTO\UserDTO $userCreate
+     * @param \App\Dto\UserEditableDto $userCreate
      * @return User
      * @throws InvalidRequestException
      * @throws UserNotFoundException
      */
-    public function updateUser(int $userId, UserDTO $userCreate): User {
+    public function updateUser(int $userId, UserEditableDto $userCreate): User {
         if($userCreate->getName() == "") {
             throw new InvalidRequestException(self::ERROR_EMPTY_USER_NAME);
         }

--- a/src/Service/UserServiceInterface.php
+++ b/src/Service/UserServiceInterface.php
@@ -2,7 +2,7 @@
 
 namespace App\Service;
 
-use App\DTO\UserDTO;
+use App\Dto\UserEditableDto;
 use App\Entity\User;
 use App\Exception\InvalidRequestException;
 use App\Exception\UserNotFoundException;
@@ -45,12 +45,12 @@ interface UserServiceInterface
      * @throws InvalidRequestException
      * @throws Exception
      */
-    public function createUser(UserDTO $userCreate): User;
+    public function createUser(UserEditableDto $userCreate): User;
 
     /**
      * @throws InvalidRequestException
      * @throws UserNotFoundException
      * @throws Exception
      */
-    public function updateUser(int $userId, UserDTO $userCreate): User;
+    public function updateUser(int $userId, UserEditableDto $userCreate): User;
 }

--- a/tests/Integration/Controller/UserControllerTest.php
+++ b/tests/Integration/Controller/UserControllerTest.php
@@ -4,7 +4,7 @@ namespace App\Tests\Integration\Controller;
 
 use App\Common\ErrorMessage;
 use App\Controller\UserController;
-use App\DTO\UserDTO;
+use App\Dto\UserEditableDto;
 use App\Entity\User;
 use App\Exception\InvalidRequestException;
 use App\Service\UserService;
@@ -172,7 +172,7 @@ class UserControllerTest extends KernelTestCase
 
     public function testCreateUserSuccess(): void
     {
-        $userCreate = new UserDTO(
+        $userCreate = new UserEditableDto(
             self::USER_NAME_TEST,
             self::USER_EMAIL_TEST,
             self::USER_PASSWORD_TEST,
@@ -201,7 +201,7 @@ class UserControllerTest extends KernelTestCase
 
     public function testCreateUserEmptyName(): void
     {
-        $userCreate = new UserDTO(
+        $userCreate = new UserEditableDto(
             "",
             self::USER_EMAIL_TEST,
             self::USER_PASSWORD_TEST,
@@ -225,7 +225,7 @@ class UserControllerTest extends KernelTestCase
 
     public function testCreateUserEmptyEmail(): void
     {
-        $userCreate = new UserDTO(
+        $userCreate = new UserEditableDto(
             self::USER_NAME_TEST,
             "",
             self::USER_PASSWORD_TEST,
@@ -249,7 +249,7 @@ class UserControllerTest extends KernelTestCase
 
     public function testCreateUserEmptyPassword(): void
     {
-        $userCreate = new UserDTO(
+        $userCreate = new UserEditableDto(
             self::USER_NAME_TEST,
             self::USER_EMAIL_TEST,
             "",
@@ -275,7 +275,7 @@ class UserControllerTest extends KernelTestCase
     {
         $existingUser = $this->addUser();
 
-        $userCreate = new UserDTO(
+        $userCreate = new UserEditableDto(
             self::NEW_USER_NAME_TEST,
             self::NEW_USER_EMAIL_TEST,
             self::NEW_USER_PASSWORD_TEST,
@@ -300,7 +300,7 @@ class UserControllerTest extends KernelTestCase
     {
         $existingUser = $this->addUser();
 
-        $userCreate = new UserDTO(
+        $userCreate = new UserEditableDto(
             "",
             self::NEW_USER_EMAIL_TEST,
             self::NEW_USER_PASSWORD_TEST,
@@ -328,7 +328,7 @@ class UserControllerTest extends KernelTestCase
     {
         $existingUser = $this->addUser();
 
-        $userCreate = new UserDTO(
+        $userCreate = new UserEditableDto(
             self::NEW_USER_NAME_TEST,
             "",
             self::NEW_USER_PASSWORD_TEST,
@@ -354,7 +354,7 @@ class UserControllerTest extends KernelTestCase
 
     public function testUpdateUserNotFound(): void
     {
-        $userCreate = new UserDTO(
+        $userCreate = new UserEditableDto(
             self::NEW_USER_NAME_TEST,
             self::NEW_USER_EMAIL_TEST,
             self::NEW_USER_PASSWORD_TEST,

--- a/tests/Integration/Service/UserServiceTest.php
+++ b/tests/Integration/Service/UserServiceTest.php
@@ -3,7 +3,7 @@
 namespace App\Tests\Integration\Service;
 
 use App\Controller\UserController;
-use App\DTO\UserDTO;
+use App\Dto\UserEditableDto;
 use App\Entity\User;
 use App\Exception\InvalidRequestException;
 use App\Exception\UserNotFoundException;
@@ -133,7 +133,7 @@ class UserServiceTest extends KernelTestCase
 
     public function testCreateUserSuccess(): void
     {
-        $userCreate = new UserDTO(
+        $userCreate = new UserEditableDto(
             self::USER_NAME_TEST,
             self::USER_EMAIL_TEST,
             self::USER_PASSWORD_TEST,
@@ -157,7 +157,7 @@ class UserServiceTest extends KernelTestCase
     {
         $existingUser = $this->addUser();
 
-        $userCreate = new UserDTO(
+        $userCreate = new UserEditableDto(
             self::NEW_USER_NAME_TEST,
             self::NEW_USER_EMAIL_TEST,
             self::NEW_USER_PASSWORD_TEST,
@@ -181,7 +181,7 @@ class UserServiceTest extends KernelTestCase
     {
         $existingUser = $this->addUser();
 
-        $userCreate = new UserDTO(
+        $userCreate = new UserEditableDto(
             "",
             self::NEW_USER_EMAIL_TEST,
             self::NEW_USER_PASSWORD_TEST,
@@ -202,7 +202,7 @@ class UserServiceTest extends KernelTestCase
     {
         $existingUser = $this->addUser();
 
-        $userCreate = new UserDTO(
+        $userCreate = new UserEditableDto(
             self::NEW_USER_NAME_TEST,
             "",
             self::NEW_USER_PASSWORD_TEST,
@@ -222,7 +222,7 @@ class UserServiceTest extends KernelTestCase
     public function testUpdateUserNotFound(): void
     {
         $userId = 1;
-        $userCreate = new UserDTO(
+        $userCreate = new UserEditableDto(
             "new name",
             "new_email@domain.com",
             "new password",

--- a/tests/Unit/Controller/UserControllerTest.php
+++ b/tests/Unit/Controller/UserControllerTest.php
@@ -4,7 +4,7 @@ namespace App\Tests\Unit\Controller;
 
 use App\Common\ErrorMessage;
 use App\Controller\UserController;
-use App\DTO\UserDTO;
+use App\Dto\UserEditableDto;
 use App\Entity\User;
 use App\Exception\InvalidRequestException;
 use App\Exception\UserNotFoundException;
@@ -200,7 +200,7 @@ class UserControllerTest extends TestCase
 
     public function testCreateUserSuccess(): void
     {
-        $userCreate = new UserDTO(
+        $userCreate = new UserEditableDto(
             self::USER_NAME_TEST,
             self::USER_EMAIL_TEST,
             self::USER_PASSWORD_TEST,
@@ -242,7 +242,7 @@ class UserControllerTest extends TestCase
 
     public function testCreateUserInvalidRequestException(): void
     {
-        $userCreate = new UserDTO(
+        $userCreate = new UserEditableDto(
             "",
             self::USER_EMAIL_TEST,
             self::USER_PASSWORD_TEST,
@@ -273,7 +273,7 @@ class UserControllerTest extends TestCase
 
     public function testCreateUserRepositoryError(): void
     {
-        $userCreate = new UserDTO(
+        $userCreate = new UserEditableDto(
             self::USER_NAME_TEST,
             self::USER_EMAIL_TEST,
             self::USER_PASSWORD_TEST,
@@ -297,7 +297,7 @@ class UserControllerTest extends TestCase
     public function testUpdateUserSuccess(): void
     {
         $userId = 1;
-        $userCreate = new UserDTO(
+        $userCreate = new UserEditableDto(
             self::USER_NAME_TEST,
             self::USER_EMAIL_TEST,
             self::USER_PASSWORD_TEST,
@@ -328,7 +328,7 @@ class UserControllerTest extends TestCase
     public function testUpdateUserNotfound(): void
     {
         $userId = 1;
-        $userCreate = new UserDTO(
+        $userCreate = new UserEditableDto(
             self::USER_NAME_TEST,
             self::USER_EMAIL_TEST,
             self::USER_PASSWORD_TEST,
@@ -352,7 +352,7 @@ class UserControllerTest extends TestCase
     public function testUpdateUserError(): void
     {
         $userId = 1;
-        $userCreate = new UserDTO(
+        $userCreate = new UserEditableDto(
             self::USER_NAME_TEST,
             self::USER_EMAIL_TEST,
             self::USER_PASSWORD_TEST,

--- a/tests/Unit/Controller/UserControllerTest.php
+++ b/tests/Unit/Controller/UserControllerTest.php
@@ -358,12 +358,6 @@ class UserControllerTest extends TestCase
             self::USER_PASSWORD_TEST,
             self::USER_PHONE_TEST,
         );
-        $user = new User(
-            self::USER_NAME_TEST,
-            self::USER_EMAIL_TEST,
-            self::USER_PASSWORD_TEST,
-            self::USER_PHONE_TEST,
-        );
 
         $userService = $this->createMock(UserServiceInterface::class);
         $userService->expects(self::once())

--- a/tests/Unit/DTO/ErrorDTOTest.php
+++ b/tests/Unit/DTO/ErrorDTOTest.php
@@ -2,7 +2,7 @@
 
 namespace App\Tests\Unit\DTO;
 
-use App\DTO\ErrorDTO;
+use App\Dto\ErrorDto;
 use PHPUnit\Framework\TestCase;
 
 class ErrorDTOTest extends TestCase{
@@ -12,7 +12,7 @@ class ErrorDTOTest extends TestCase{
     public function testErrorDTOConstruct() {
         $exception = new \Exception(self::DEFAULT_ERROR_MESSAGE, self::DEFAULT_ERROR_CODE);
 
-        $user = new ErrorDTO($exception);
+        $user = new ErrorDto($exception);
 
         $this->assertIsObject($user);
         $this->assertEquals(self::DEFAULT_ERROR_MESSAGE, $user->getMessage());
@@ -22,7 +22,7 @@ class ErrorDTOTest extends TestCase{
     public function testErrorDTOMessage() {
         $testException = new \Exception();
 
-        $user = new ErrorDTO($testException);
+        $user = new ErrorDto($testException);
 
         $user->setMessage(self::DEFAULT_ERROR_MESSAGE);
 
@@ -32,7 +32,7 @@ class ErrorDTOTest extends TestCase{
     public function testErrorDTOCode() {
         $testException = new \Exception();
 
-        $user = new ErrorDTO($testException);
+        $user = new ErrorDto($testException);
 
         $user->setCode(self::DEFAULT_ERROR_CODE);
 

--- a/tests/Unit/Dto/ErrorDtoTest.php
+++ b/tests/Unit/Dto/ErrorDtoTest.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace App\Tests\Unit\DTO;
+namespace App\Tests\Unit\Dto;
 
 use App\Dto\ErrorDto;
 use PHPUnit\Framework\TestCase;
 
-class ErrorDTOTest extends TestCase{
+class ErrorDtoTest extends TestCase{
     const DEFAULT_ERROR_MESSAGE = "error message";
     const DEFAULT_ERROR_CODE = 20;
 
-    public function testErrorDTOConstruct() {
+    public function testErrorDtoConstruct() {
         $exception = new \Exception(self::DEFAULT_ERROR_MESSAGE, self::DEFAULT_ERROR_CODE);
 
         $user = new ErrorDto($exception);
@@ -19,7 +19,7 @@ class ErrorDTOTest extends TestCase{
         $this->assertEquals(self::DEFAULT_ERROR_CODE, $user->getCode());
     }
 
-    public function testErrorDTOMessage() {
+    public function testErrorDtoMessage() {
         $testException = new \Exception();
 
         $user = new ErrorDto($testException);
@@ -29,7 +29,7 @@ class ErrorDTOTest extends TestCase{
         $this->assertEquals(self::DEFAULT_ERROR_MESSAGE, $user->getMessage());
     }
 
-    public function testErrorDTOCode() {
+    public function testErrorDtoCode() {
         $testException = new \Exception();
 
         $user = new ErrorDto($testException);

--- a/tests/Unit/Dto/UserEditableDtoTest.php
+++ b/tests/Unit/Dto/UserEditableDtoTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Tests\Unit\Dto;
+
+use App\Dto\UserEditableDto;
+use App\Tests\Utils\ConstHelper;
+use PHPUnit\Framework\TestCase;
+
+class UserEditableDtoTest extends TestCase{
+    public function testUserEditableDtoConstruct() {
+        $user = new UserEditableDto(
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PASSWORD_TEST,
+            ConstHelper::USER_PHONE_TEST,
+        );
+
+        $this->assertIsObject($user);
+        $this->assertEquals(ConstHelper::USER_NAME_TEST, $user->getName());
+        $this->assertEquals(ConstHelper::USER_EMAIL_TEST, $user->getEmail());
+        $this->assertEquals(ConstHelper::USER_PASSWORD_TEST, $user->getPassword());
+        $this->assertEquals(ConstHelper::USER_PHONE_TEST, $user->getPhone());
+    }
+
+    public function testUserEditableDtoName() {
+        $user = new UserEditableDto(
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PASSWORD_TEST,
+            ConstHelper::USER_PHONE_TEST,
+        );
+
+        $user->setName(ConstHelper::NEW_USER_NAME_TEST);
+
+        $this->assertIsObject($user);
+        $this->assertEquals(ConstHelper::NEW_USER_NAME_TEST, $user->getName());
+    }
+
+    public function testUserEditableDtoEmail() {
+        $user = new UserEditableDto(
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PASSWORD_TEST,
+            ConstHelper::USER_PHONE_TEST,
+        );
+
+        $user->setEmail(ConstHelper::NEW_USER_EMAIL_TEST);
+
+        $this->assertIsObject($user);
+        $this->assertEquals(ConstHelper::NEW_USER_EMAIL_TEST, $user->getEmail());
+    }
+
+    public function testUserEditableDtoPassword() {
+        $user = new UserEditableDto(
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PASSWORD_TEST,
+            ConstHelper::USER_PHONE_TEST,
+        );
+
+        $user->setPassword(ConstHelper::NEW_USER_PASSWORD_TEST);
+
+        $this->assertIsObject($user);
+        $this->assertEquals(ConstHelper::NEW_USER_PASSWORD_TEST, $user->getPassword());
+    }
+
+    public function testUserEditableDtoPhone() {
+        $user = new UserEditableDto(
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PASSWORD_TEST,
+            ConstHelper::USER_PHONE_TEST,
+        );
+
+        $user->setPhone(ConstHelper::NEW_USER_PHONE_TEST);
+
+        $this->assertIsObject($user);
+        $this->assertEquals(ConstHelper::NEW_USER_PHONE_TEST, $user->getPhone());
+    }
+}

--- a/tests/Unit/Service/UserServiceTest.php
+++ b/tests/Unit/Service/UserServiceTest.php
@@ -2,7 +2,7 @@
 
 namespace App\Tests\Unit\Service;
 
-use App\DTO\UserDTO;
+use App\Dto\UserEditableDto;
 use App\Entity\User;
 use App\Exception\InvalidRequestException;
 use App\Exception\UserNotFoundException;
@@ -180,7 +180,7 @@ class UserServiceTest extends TestCase
 
     public function testCreateUserSuccess(): void
     {
-        $userCreate = new UserDTO(
+        $userCreate = new UserEditableDto(
             self::USER_NAME_TEST,
             self::USER_EMAIL_TEST,
             self::USER_PASSWORD_TEST,
@@ -207,7 +207,7 @@ class UserServiceTest extends TestCase
 
     public function testCreateUserEmptyName(): void
     {
-        $userCreate = new UserDTO(
+        $userCreate = new UserEditableDto(
             "",
             self::USER_EMAIL_TEST,
             self::USER_PASSWORD_TEST,
@@ -224,7 +224,7 @@ class UserServiceTest extends TestCase
 
     public function testCreateUserEmptyEmail(): void
     {
-        $userCreate = new UserDTO(
+        $userCreate = new UserEditableDto(
             self::USER_NAME_TEST,
             "",
             self::USER_PASSWORD_TEST,
@@ -241,7 +241,7 @@ class UserServiceTest extends TestCase
 
     public function testCreateUserEmptyPassword(): void
     {
-        $userCreate = new UserDTO(
+        $userCreate = new UserEditableDto(
             self::USER_NAME_TEST,
             self::USER_EMAIL_TEST,
             "",
@@ -258,7 +258,7 @@ class UserServiceTest extends TestCase
 
     public function testCreateUserRepositorySaveError(): void
     {
-        $userCreate = new UserDTO(
+        $userCreate = new UserEditableDto(
             self::USER_NAME_TEST,
             self::USER_EMAIL_TEST,
             self::USER_PASSWORD_TEST,
@@ -286,7 +286,7 @@ class UserServiceTest extends TestCase
     public function testUpdateUserSuccess(): void
     {
         $userId = 1;
-        $userCreate = new UserDTO(
+        $userCreate = new UserEditableDto(
             self::USER_NAME_TEST,
             self::USER_EMAIL_TEST,
             self::USER_PASSWORD_TEST,
@@ -317,7 +317,7 @@ class UserServiceTest extends TestCase
     public function testUpdateUserEmptyName(): void
     {
         $userId = 1;
-        $userCreate = new UserDTO(
+        $userCreate = new UserEditableDto(
             "",
             self::USER_EMAIL_TEST,
             self::USER_PASSWORD_TEST,
@@ -335,7 +335,7 @@ class UserServiceTest extends TestCase
     public function testUpdateUserEmptyEmail(): void
     {
         $userId = 1;
-        $userCreate = new UserDTO(
+        $userCreate = new UserEditableDto(
             self::USER_NAME_TEST,
             "",
             self::USER_PASSWORD_TEST,
@@ -353,7 +353,7 @@ class UserServiceTest extends TestCase
     public function testUpdateUserNotFound(): void
     {
         $userId = 1;
-        $userCreate = new UserDTO(
+        $userCreate = new UserEditableDto(
             self::USER_NAME_TEST,
             self::USER_EMAIL_TEST,
             self::USER_PASSWORD_TEST,
@@ -375,7 +375,7 @@ class UserServiceTest extends TestCase
     public function testUpdateUserRepositoryFindError(): void
     {
         $userId = 1;
-        $userCreate = new UserDTO(
+        $userCreate = new UserEditableDto(
             self::USER_NAME_TEST,
             self::USER_EMAIL_TEST,
             self::USER_PASSWORD_TEST,
@@ -397,7 +397,7 @@ class UserServiceTest extends TestCase
     public function testUpdateUserRepositorySaveError(): void
     {
         $userId = 1;
-        $userCreate = new UserDTO(
+        $userCreate = new UserEditableDto(
             self::USER_NAME_TEST,
             self::USER_EMAIL_TEST,
             self::USER_PASSWORD_TEST,

--- a/tests/Utils/ConstHelper.php
+++ b/tests/Utils/ConstHelper.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Tests\Utils;
+
+class ConstHelper {
+    const USER_NAME_TEST = "name";
+    const USER_EMAIL_TEST = "email@domain.com";
+    const USER_PASSWORD_TEST = "password";
+    const USER_PHONE_TEST = "910123123";
+    const NEW_USER_NAME_TEST = "new name";
+    const NEW_USER_EMAIL_TEST = "new_email@domain.com";
+    const NEW_USER_PASSWORD_TEST = "new_password";
+    const NEW_USER_PHONE_TEST = "910111222";
+}


### PR DESCRIPTION
## Changes
* Rename `ErrorDTO` to `ErrorDto`.
* Rename `UserDTO` to `UserEditableDto`.
* Add `ConstHelper` to support commonly instantiated in each test class.
* Add `UserEditableDto` tests.
* Update `UserEditableDto` in `openapi.yml` specs.