### PR TITLE
chore: add UserDto return to service methods

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -21,7 +21,7 @@ paths:
                             schema:
                                 type: array
                                 items:
-                                    $ref: '#/components/schemas/User'
+                                    $ref: '#/components/schemas/UserDto'
         post:
             operationId: createUser
             description: Creates a user and returns created user when succeeds.
@@ -40,7 +40,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/User'
+                                $ref: '#/components/schemas/UserDto'
                 '400':
                     description: Invalid user create request.
                     content:
@@ -66,7 +66,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/User'
+                                $ref: '#/components/schemas/UserDto'
                 '404':
                     description: User was not found for the given Id.
                     content:
@@ -98,7 +98,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/User'
+                                $ref: '#/components/schemas/UserDto'
                 '400':
                     description: Invalid user create request.
                     content:
@@ -129,7 +129,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/User'
+                                $ref: '#/components/schemas/UserDto'
                 '404':
                     description: User with the given user Id doesn't exist.
                     content:
@@ -156,7 +156,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/User'
+                                $ref: '#/components/schemas/UserDto'
                 '404':
                     description: User was not found for the given email.
                     content:
@@ -165,7 +165,7 @@ paths:
                                 $ref: '#/components/schemas/Error'
 components:
     schemas:
-        User:
+        UserDto:
             type: object
             properties:
                 id:
@@ -176,8 +176,6 @@ components:
                 email:
                     type: string
                     format: email
-                password:
-                    type: string
                 phone:
                     type: string
                 createdAt:

--- a/src/Dto/UserDto.php
+++ b/src/Dto/UserDto.php
@@ -2,50 +2,51 @@
 
 namespace App\Dto;
 
+use DateTimeInterface;
+
 /**
  * UserDTO holds returnable data for a user.
  */
 class UserDto
 {
     /**
-     * @var string|null
+     * @var string
      */
-    private ?string $name = null;
+    private string $name;
 
     /**
-     * @var string|null
+     * @var string
      */
-    private ?string $email = null;
+    private string $email;
 
     /**
-     * @var string|null
+     * @var string
      */
-    private ?string $phone = null;
+    private string $phone;
 
     /**
-     * @var \DateTimeInterface|null
+     * @var DateTimeInterface|null
      */
-    private ?\DateTimeInterface $createdAt;
+    private ?DateTimeInterface $createdAt;
 
     /**
-     * @var \DateTimeInterface|null
+     * @var DateTimeInterface|null
      */
-    private ?\DateTimeInterface $updatedAt;
-
+    private ?DateTimeInterface $updatedAt;
 
     /**
      * @param string $name
      * @param string $email
      * @param string $phone
-     * @param \DateTimeInterface|null $createdAt
-     * @param \DateTimeInterface|null $updatedAt
+     * @param DateTimeInterface|null $createdAt
+     * @param DateTimeInterface|null $updatedAt
      */
     public function __construct(
-        string $name,
-        string $email,
-        string $phone,
-        \DateTimeInterface $createdAt = null,
-        \DateTimeInterface $updatedAt = null,
+        string             $name,
+        string             $email,
+        string             $phone,
+        ?DateTimeInterface $createdAt = null,
+        ?DateTimeInterface $updatedAt = null,
     ) {
         $this->name = $name;
         $this->email = $email;
@@ -55,9 +56,9 @@ class UserDto
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getName(): string {
+    public function getName(): ?string {
         return $this->name;
     }
 
@@ -85,9 +86,9 @@ class UserDto
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getPhone(): string {
+    public function getPhone(): ?string {
         return $this->phone;
     }
 
@@ -100,20 +101,20 @@ class UserDto
     }
 
     /**
-     * @return \DateTimeInterface
+     * @return DateTimeInterface
      */
-    public function getCreatedAt(): \DateTimeInterface {
+    public function getCreatedAt(): DateTimeInterface {
         return $this->createdAt;
     }
 
     /**
-     * @param \DateTime|string $createdAt
+     * @param DateTimeInterface|string $createdAt
      * @return void
      */
-    public function setCreatedAt(\DateTime|string $createdAt): void {
+    public function setCreatedAt(DateTimeInterface|string $createdAt): void {
         // Fix: deserialize set datetime error
         if(gettype($createdAt) == "string") {
-            $this->createdAt = date_create_from_format(\DateTimeInterface::RFC3339, $createdAt);
+            $this->createdAt = date_create_from_format(DateTimeInterface::RFC3339, $createdAt);
             return;
         }
 
@@ -121,20 +122,20 @@ class UserDto
     }
 
     /**
-     * @return \DateTimeInterface
+     * @return DateTimeInterface|null
      */
-    public function getUpdatedAt(): \DateTimeInterface {
+    public function getUpdatedAt(): ?DateTimeInterface {
         return $this->updatedAt;
     }
 
     /**
-     * @param \DateTimeInterface|string $updatedAt
+     * @param DateTimeInterface|string|null $updatedAt
      * @return void
      */
-    public function setUpdatedAt(\DateTime|string $updatedAt): void {
+    public function setUpdatedAt(DateTimeInterface|string|null $updatedAt): void {
         // Fix: deserialize set datetime error
         if(gettype($updatedAt) == "string") {
-            $this->createdAt = date_create_from_format(\DateTimeInterface::RFC3339, $updatedAt);
+            $this->createdAt = date_create_from_format(DateTimeInterface::RFC3339, $updatedAt);
             return;
         }
 

--- a/src/Dto/UserDto.php
+++ b/src/Dto/UserDto.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\DTO;
+
+/**
+ * UserDTO holds editable attributes for creating/updating a user.
+ */
+class UserDTO
+{
+    /**
+     * @var string|null
+     */
+    private ?string $name = null;
+
+    /**
+     * @var string|null
+     */
+    private ?string $email = null;
+
+    /**
+     * @var string|null
+     */
+    private ?string $password = null;
+
+    /**
+     * @var string|null
+     */
+    private ?string $phone = null;
+
+    /**
+     * @param string $name
+     * @param string $email
+     * @param string $password
+     * @param string $phone
+     */
+    public function __construct(string $name, string $email, string $password, string $phone) {
+        $this->name = $name;
+        $this->email = $email;
+        $this->password = $password;
+        $this->phone = $phone;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName(): string {
+        return $this->name;
+    }
+
+    /**
+     * @param string $name
+     * @return void
+     */
+    public function setName(string $name): void {
+        $this->name = $name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getEmail(): string {
+        return $this->email;
+    }
+
+    /**
+     * @param string $email
+     * @return void
+     */
+    public function setEmail(string $email): void {
+        $this->email = $email;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPhone(): string {
+        return $this->phone;
+    }
+
+    /**
+     * @param string $phone
+     * @return void
+     */
+    public function setPhone(string $phone): void {
+        $this->phone = $phone;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPassword(): string {
+        return $this->password;
+    }
+
+    /**
+     * @param string $password
+     * @return void
+     */
+    public function setPassword(string $password): void {
+        $this->password = $password;
+    }
+}

--- a/src/Dto/UserDto.php
+++ b/src/Dto/UserDto.php
@@ -10,6 +10,11 @@ use DateTimeInterface;
 class UserDto
 {
     /**
+     * @var int
+     */
+    private int $id;
+
+    /**
      * @var string
      */
     private string $name;
@@ -35,6 +40,7 @@ class UserDto
     private ?DateTimeInterface $updatedAt;
 
     /**
+     * @param int $int
      * @param string $name
      * @param string $email
      * @param string $phone
@@ -42,17 +48,34 @@ class UserDto
      * @param DateTimeInterface|null $updatedAt
      */
     public function __construct(
+        int                $id,
         string             $name,
         string             $email,
         string             $phone,
         ?DateTimeInterface $createdAt = null,
         ?DateTimeInterface $updatedAt = null,
     ) {
+        $this->id = $id;
         $this->name = $name;
         $this->email = $email;
         $this->phone = $phone;
         $this->createdAt = $createdAt;
         $this->updatedAt = $updatedAt;
+    }
+
+    /**
+     * @return int
+     */
+    public function getId(): int {
+        return $this->id;
+    }
+
+    /**
+     * @param int $id
+     * @return void
+     */
+    public function setId(int $id): void {
+        $this->id = $id;
     }
 
     /**

--- a/src/Dto/UserDto.php
+++ b/src/Dto/UserDto.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace App\DTO;
+namespace App\Dto;
 
 /**
- * UserDTO holds editable attributes for creating/updating a user.
+ * UserDTO holds returnable data for a user.
  */
-class UserDTO
+class UserDto
 {
     /**
      * @var string|null
@@ -20,24 +20,38 @@ class UserDTO
     /**
      * @var string|null
      */
-    private ?string $password = null;
+    private ?string $phone = null;
 
     /**
-     * @var string|null
+     * @var \DateTimeInterface|null
      */
-    private ?string $phone = null;
+    private ?\DateTimeInterface $createdAt;
+
+    /**
+     * @var \DateTimeInterface|null
+     */
+    private ?\DateTimeInterface $updatedAt;
+
 
     /**
      * @param string $name
      * @param string $email
-     * @param string $password
      * @param string $phone
+     * @param \DateTimeInterface|null $createdAt
+     * @param \DateTimeInterface|null $updatedAt
      */
-    public function __construct(string $name, string $email, string $password, string $phone) {
+    public function __construct(
+        string $name,
+        string $email,
+        string $phone,
+        \DateTimeInterface $createdAt = null,
+        \DateTimeInterface $updatedAt = null,
+    ) {
         $this->name = $name;
         $this->email = $email;
-        $this->password = $password;
         $this->phone = $phone;
+        $this->createdAt = $createdAt;
+        $this->updatedAt = $updatedAt;
     }
 
     /**
@@ -86,17 +100,44 @@ class UserDTO
     }
 
     /**
-     * @return string
+     * @return \DateTimeInterface
      */
-    public function getPassword(): string {
-        return $this->password;
+    public function getCreatedAt(): \DateTimeInterface {
+        return $this->createdAt;
     }
 
     /**
-     * @param string $password
+     * @param \DateTime|string $createdAt
      * @return void
      */
-    public function setPassword(string $password): void {
-        $this->password = $password;
+    public function setCreatedAt(\DateTime|string $createdAt): void {
+        // Fix: deserialize set datetime error
+        if(gettype($createdAt) == "string") {
+            $this->createdAt = date_create_from_format(\DateTimeInterface::RFC3339, $createdAt);
+            return;
+        }
+
+        $this->createdAt = $createdAt;
+    }
+
+    /**
+     * @return \DateTimeInterface
+     */
+    public function getUpdatedAt(): \DateTimeInterface {
+        return $this->updatedAt;
+    }
+
+    /**
+     * @param \DateTimeInterface|string $updatedAt
+     * @return void
+     */
+    public function setUpdatedAt(\DateTime|string $updatedAt): void {
+        // Fix: deserialize set datetime error
+        if(gettype($updatedAt) == "string") {
+            $this->createdAt = date_create_from_format(\DateTimeInterface::RFC3339, $updatedAt);
+            return;
+        }
+
+        $this->updatedAt = $updatedAt;
     }
 }

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -79,6 +79,14 @@ class User
     }
 
     /**
+     * @param int $id
+     * @return void
+     */
+    public function setId(int $id): void {
+        $this->id = $id;
+    }
+
+    /**
      * @return string
      */
     public function getName(): string {

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -21,16 +21,16 @@ class User
     private ?int $id = null;
 
     /**
-     * @var string|null
+     * @var string
      */
     #[ORM\Column(length: 255)]
-    private ?string $name = null;
+    private string $name;
 
     /**
-     * @var string|null
+     * @var string
      */
     #[ORM\Column(length: 255)]
-    private ?string $email = null;
+    private string $email;
 
     /**
      * @var string|null
@@ -39,10 +39,10 @@ class User
     private ?string $password = null;
 
     /**
-     * @var string|null
+     * @var string
      */
     #[ORM\Column(length: 20)]
-    private ?string $phone = null;
+    private string $phone;
 
     /**
      * @var \DateTime
@@ -160,9 +160,9 @@ class User
     }
 
     /**
-     * @return \DateTime
+     * @return \DateTimeInterface|null
      */
-    public function getUpdatedAt(): \DateTime {
+    public function getUpdatedAt(): ?\DateTimeInterface {
         return $this->updatedAt;
     }
 

--- a/src/Mapper/UserMapper.php
+++ b/src/Mapper/UserMapper.php
@@ -3,6 +3,7 @@
 namespace App\Mapper;
 
 use App\Dto\UserDto;
+use App\Dto\UserEditableDto;
 use App\Entity\User;
 
 class UserMapper {
@@ -10,7 +11,7 @@ class UserMapper {
      * @param User $entity
      * @return UserDto
      */
-    public static function EntityToDto(User $entity): UserDto {
+    public static function entityToDto(User $entity): UserDto {
         return new UserDto(
             $entity->getName(),
             $entity->getEmail(),
@@ -24,13 +25,26 @@ class UserMapper {
      * @param User[] $entities
      * @return UserDto[]
      */
-    public static function EntityToDtoArray(array $entities): array {
+    public static function entityToDtoArray(array $entities): array {
         $values = [];
 
         foreach($entities as $entity) {
-            $values[] = self::EntityToDto($entity);
+            $values[] = self::entityToDto($entity);
         }
 
         return $values;
+    }
+
+    /**
+     * @param UserEditableDto $userEditableDto
+     * @return User
+     */
+    public static function userEditableDtoToEntity(UserEditableDto $userEditableDto): User {
+        return new User(
+            $userEditableDto->getName(),
+            $userEditableDto->getEmail(),
+            $userEditableDto->getPassword(),
+            $userEditableDto->getPhone(),
+        );
     }
 }

--- a/src/Mapper/UserMapper.php
+++ b/src/Mapper/UserMapper.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Mapper;
+
+use App\Dto\UserDto;
+use App\Entity\User;
+
+class UserMapper {
+    /**
+     * @param User $entity
+     * @return UserDto
+     */
+    public static function EntityToDto(User $entity): UserDto {
+        return new UserDto(
+            $entity->getName(),
+            $entity->getEmail(),
+            $entity->getPhone(),
+            $entity->getCreatedAt(),
+            $entity->getUpdatedAt(),
+        );
+    }
+
+    /**
+     * @param User[] $entities
+     * @return UserDto[]
+     */
+    public static function EntityToDtoArray(array $entities): array {
+        $values = [];
+
+        foreach($entities as $entity) {
+            $values[] = self::EntityToDto($entity);
+        }
+
+        return $values;
+    }
+}

--- a/src/Mapper/UserMapper.php
+++ b/src/Mapper/UserMapper.php
@@ -13,6 +13,7 @@ class UserMapper {
      */
     public static function entityToDto(User $entity): UserDto {
         return new UserDto(
+            $entity->getId(),
             $entity->getName(),
             $entity->getEmail(),
             $entity->getPhone(),

--- a/src/Service/UserService.php
+++ b/src/Service/UserService.php
@@ -6,6 +6,7 @@ use App\Dto\UserEditableDto;
 use App\Entity\User;
 use App\Exception\InvalidRequestException;
 use App\Exception\UserNotFoundException;
+use App\Mapper\UserMapper;
 use App\Repository\UserRepositoryInterface;
 
 /**
@@ -84,22 +85,22 @@ class UserService implements UserServiceInterface {
      * @return User
      * @throws InvalidRequestException
      */
-    public function createUser(UserEditableDto $userCreate): User {
-        if($userCreate->getName() == "") {
+    public function createUser(UserEditableDto $userEditable): User {
+        if($userEditable->getName() == "") {
             throw new InvalidRequestException(self::ERROR_EMPTY_USER_NAME);
         }
-        if($userCreate->getEmail() == "") {
+        if($userEditable->getEmail() == "") {
             throw new InvalidRequestException(self::ERROR_EMPTY_USER_EMAIL);
         }
-        if($userCreate->getPassword() == "") {
+        if($userEditable->getPassword() == "") {
             throw new InvalidRequestException(self::ERROR_EMPTY_USER_PASSWORD);
         }
 
         $user = new User(
-            $userCreate->getName(),
-            $userCreate->getEmail(),
-            $userCreate->getPassword(),
-            $userCreate->getPhone(),
+            $userEditable->getName(),
+            $userEditable->getEmail(),
+            $userEditable->getPassword(),
+            $userEditable->getPhone(),
         );
 
         return $this->userRepository->save($user, true);
@@ -112,11 +113,11 @@ class UserService implements UserServiceInterface {
      * @throws InvalidRequestException
      * @throws UserNotFoundException
      */
-    public function updateUser(int $userId, UserEditableDto $userCreate): User {
-        if($userCreate->getName() == "") {
+    public function updateUser(int $userId, UserEditableDto $userEditable): User {
+        if($userEditable->getName() == "") {
             throw new InvalidRequestException(self::ERROR_EMPTY_USER_NAME);
         }
-        if($userCreate->getEmail() == "") {
+        if($userEditable->getEmail() == "") {
             throw new InvalidRequestException(self::ERROR_EMPTY_USER_EMAIL);
         }
 
@@ -125,13 +126,13 @@ class UserService implements UserServiceInterface {
             throw new UserNotFoundException($userId);
         }
 
-        $user->setName($userCreate->getName());
-        $user->setEmail($userCreate->getEmail());
-        $user->setPhone($userCreate->getPhone());
+        $user->setName($userEditable->getName());
+        $user->setEmail($userEditable->getEmail());
+        $user->setPhone($userEditable->getPhone());
         $user->setUpdatedAt(new \DateTime());
 
-        if($userCreate->getPassword()!="") {
-            $user->setPassword($userCreate->getPassword());
+        if($userEditable->getPassword()!="") {
+            $user->setPassword($userEditable->getPassword());
         }
 
         $this->userRepository->save($user, true);

--- a/src/Service/UserService.php
+++ b/src/Service/UserService.php
@@ -61,10 +61,12 @@ class UserService implements UserServiceInterface {
     }
 
     /**
-     * @return array
+     * @return UserDto[]
      */
     public function findAllUsers(): array {
-        return $this->userRepository->findAll();
+        $users = $this->userRepository->findAll();
+
+        return UserMapper::entityToDtoArray($users);
     }
 
     /**

--- a/src/Service/UserService.php
+++ b/src/Service/UserService.php
@@ -99,12 +99,7 @@ class UserService implements UserServiceInterface {
             throw new InvalidRequestException(self::ERROR_EMPTY_USER_PASSWORD);
         }
 
-        $user = new User(
-            $userEditable->getName(),
-            $userEditable->getEmail(),
-            $userEditable->getPassword(),
-            $userEditable->getPhone(),
-        );
+        $user = UserMapper::userEditableDtoToEntity($userEditable);
 
         $newUser = $this->userRepository->save($user, true);
 

--- a/src/Service/UserService.php
+++ b/src/Service/UserService.php
@@ -2,6 +2,7 @@
 
 namespace App\Service;
 
+use App\Dto\UserDto;
 use App\Dto\UserEditableDto;
 use App\Entity\User;
 use App\Exception\InvalidRequestException;
@@ -32,16 +33,16 @@ class UserService implements UserServiceInterface {
 
     /**
      * @param int $userId
-     * @return User
+     * @return UserDto
      * @throws UserNotFoundException
      */
-    public function findUser(int $userId): User {
+    public function findUser(int $userId): UserDto {
         $user = $this->userRepository->find($userId);
         if(empty($user)) {
             throw new UserNotFoundException($userId);
         }
 
-        return $user;
+        return UserMapper::entityToDto($user);
     }
 
     /**
@@ -108,7 +109,7 @@ class UserService implements UserServiceInterface {
 
     /**
      * @param int $userId
-     * @param \App\Dto\UserEditableDto $userCreate
+     * @param UserEditableDto $userEditable
      * @return User
      * @throws InvalidRequestException
      * @throws UserNotFoundException

--- a/src/Service/UserService.php
+++ b/src/Service/UserService.php
@@ -47,17 +47,17 @@ class UserService implements UserServiceInterface {
 
     /**
      * @param string $email
-     * @return User
+     * @return UserDto
      * @throws UserNotFoundException
      */
-    public function findUserByEmail(string $email): User {
+    public function findUserByEmail(string $email): UserDto {
         $user = $this->userRepository->findOneBy(["email" => $email]);
 
         if(empty($user)) {
             throw new UserNotFoundException($email);
         }
 
-        return $user;
+        return UserMapper::entityToDto($user);
     }
 
     /**

--- a/src/Service/UserService.php
+++ b/src/Service/UserService.php
@@ -114,11 +114,11 @@ class UserService implements UserServiceInterface {
     /**
      * @param int $userId
      * @param UserEditableDto $userEditable
-     * @return User
+     * @return UserDto
      * @throws InvalidRequestException
      * @throws UserNotFoundException
      */
-    public function updateUser(int $userId, UserEditableDto $userEditable): User {
+    public function updateUser(int $userId, UserEditableDto $userEditable): UserDto {
         if($userEditable->getName() == "") {
             throw new InvalidRequestException(self::ERROR_EMPTY_USER_NAME);
         }
@@ -140,8 +140,8 @@ class UserService implements UserServiceInterface {
             $user->setPassword($userEditable->getPassword());
         }
 
-        $this->userRepository->save($user, true);
+        $updatedUser = $this->userRepository->save($user, true);
 
-        return $user;
+        return UserMapper::entityToDto($updatedUser);
     }
 }

--- a/src/Service/UserService.php
+++ b/src/Service/UserService.php
@@ -84,11 +84,11 @@ class UserService implements UserServiceInterface {
     }
 
     /**
-     * @param \App\Dto\UserEditableDto $userCreate
-     * @return User
+     * @param UserEditableDto $userEditable
+     * @return UserDto
      * @throws InvalidRequestException
      */
-    public function createUser(UserEditableDto $userEditable): User {
+    public function createUser(UserEditableDto $userEditable): UserDto {
         if($userEditable->getName() == "") {
             throw new InvalidRequestException(self::ERROR_EMPTY_USER_NAME);
         }
@@ -106,7 +106,9 @@ class UserService implements UserServiceInterface {
             $userEditable->getPhone(),
         );
 
-        return $this->userRepository->save($user, true);
+        $newUser = $this->userRepository->save($user, true);
+
+        return UserMapper::entityToDto($newUser);
     }
 
     /**

--- a/src/Service/UserServiceInterface.php
+++ b/src/Service/UserServiceInterface.php
@@ -45,16 +45,16 @@ interface UserServiceInterface
     public function removeUser(int $userId): void;
 
     /**
-     * @param UserEditableDto $userCreate
+     * @param UserEditableDto $userEditable
      * @return UserDto
      * @throws Exception
      */
-    public function createUser(UserEditableDto $userCreate): UserDto;
+    public function createUser(UserEditableDto $userEditable): UserDto;
 
     /**
      * @throws InvalidRequestException
      * @throws UserNotFoundException
      * @throws Exception
      */
-    public function updateUser(int $userId, UserEditableDto $userCreate): User;
+    public function updateUser(int $userId, UserEditableDto $userEditable): UserDto;
 }

--- a/src/Service/UserServiceInterface.php
+++ b/src/Service/UserServiceInterface.php
@@ -26,7 +26,7 @@ interface UserServiceInterface
     public function findUser(int $userId): UserDto;
 
     /**
-     * @return array
+     * @return UserDto[]
      */
     public function findAllUsers(): array;
 

--- a/src/Service/UserServiceInterface.php
+++ b/src/Service/UserServiceInterface.php
@@ -45,10 +45,11 @@ interface UserServiceInterface
     public function removeUser(int $userId): void;
 
     /**
-     * @throws InvalidRequestException
+     * @param UserEditableDto $userCreate
+     * @return UserDto
      * @throws Exception
      */
-    public function createUser(UserEditableDto $userCreate): User;
+    public function createUser(UserEditableDto $userCreate): UserDto;
 
     /**
      * @throws InvalidRequestException

--- a/src/Service/UserServiceInterface.php
+++ b/src/Service/UserServiceInterface.php
@@ -2,6 +2,7 @@
 
 namespace App\Service;
 
+use App\Dto\UserDto;
 use App\Dto\UserEditableDto;
 use App\Entity\User;
 use App\Exception\InvalidRequestException;
@@ -18,9 +19,11 @@ interface UserServiceInterface
     public function __construct(UserRepositoryInterface $userRepository);
 
     /**
+     * @param int $userId
+     * @return UserDto
      * @throws UserNotFoundException
      */
-    public function findUser(int $userId): User;
+    public function findUser(int $userId): UserDto;
 
     /**
      * @return array

--- a/src/Service/UserServiceInterface.php
+++ b/src/Service/UserServiceInterface.php
@@ -32,11 +32,11 @@ interface UserServiceInterface
 
     /**
      * @param string $email
-     * @return User
+     * @return UserDto
      * @throws UserNotFoundException
      * @throws Exception
      */
-    public function findUserByEmail(string $email): User;
+    public function findUserByEmail(string $email): UserDto;
 
     /**
      * @throws UserNotFoundException

--- a/tests/Integration/Controller/UserControllerTest.php
+++ b/tests/Integration/Controller/UserControllerTest.php
@@ -9,6 +9,7 @@ use App\Entity\User;
 use App\Exception\InvalidRequestException;
 use App\Mapper\UserMapper;
 use App\Service\UserService;
+use App\Tests\Utils\ConstHelper;
 use App\Tests\Utils\RequestHelper;
 use Doctrine\ORM\EntityManager;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
@@ -23,20 +24,14 @@ use Symfony\Component\Serializer\Serializer;
 
 class UserControllerTest extends KernelTestCase
 {
-    const USER_NAME_TEST = "name";
-    const USER_EMAIL_TEST = "email@domain.com";
-    const USER_PASSWORD_TEST = "password";
-    const USER_PHONE_TEST = "910123123";
-    const NEW_USER_NAME_TEST = "new name";
-    const NEW_USER_EMAIL_TEST = "new_email@domain.com";
-    const NEW_USER_PASSWORD_TEST = "new_password";
-    const NEW_USER_PHONE_TEST = "910111222";
-
     /**
      * @var EntityManager
      */
     private EntityManager $entityManager;
 
+    /**
+     * @var Serializer
+     */
     private Serializer $serializer;
 
     protected function setUp(): void
@@ -113,7 +108,7 @@ class UserControllerTest extends KernelTestCase
         $userService = new UserService($userRepository);
         $userController = new UserController($userService);
 
-        $parameters = ["email" => self::USER_EMAIL_TEST];
+        $parameters = ["email" => ConstHelper::USER_EMAIL_TEST];
         $request = RequestHelper::createRequest("/users/email", Request::METHOD_GET, "", $parameters);
         $response = $userController->findUserByEmail($request, $this->serializer);
 
@@ -141,7 +136,7 @@ class UserControllerTest extends KernelTestCase
         $userService = new UserService($userRepository);
         $userController = new UserController($userService);
 
-        $parameters = ["email" => self::USER_EMAIL_TEST];
+        $parameters = ["email" => ConstHelper::USER_EMAIL_TEST];
         $request = RequestHelper::createRequest("/users/email", Request::METHOD_GET, "", $parameters);
         $response = $userController->findUserByEmail($request, $this->serializer);
 
@@ -175,10 +170,10 @@ class UserControllerTest extends KernelTestCase
     public function testCreateUserSuccess(): void
     {
         $userCreate = new UserEditableDto(
-            self::USER_NAME_TEST,
-            self::USER_EMAIL_TEST,
-            self::USER_PASSWORD_TEST,
-            self::USER_PHONE_TEST,
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PASSWORD_TEST,
+            ConstHelper::USER_PHONE_TEST,
         );
 
         $userRepository = $this->entityManager->getRepository(User::class);
@@ -205,9 +200,9 @@ class UserControllerTest extends KernelTestCase
     {
         $userCreate = new UserEditableDto(
             "",
-            self::USER_EMAIL_TEST,
-            self::USER_PASSWORD_TEST,
-            self::USER_PHONE_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PASSWORD_TEST,
+            ConstHelper::USER_PHONE_TEST,
         );
         $exception = new InvalidRequestException(UserService::ERROR_EMPTY_USER_NAME);
         $errorMessage = ErrorMessage::generate($exception, $this->serializer);
@@ -228,10 +223,10 @@ class UserControllerTest extends KernelTestCase
     public function testCreateUserEmptyEmail(): void
     {
         $userCreate = new UserEditableDto(
-            self::USER_NAME_TEST,
+            ConstHelper::USER_NAME_TEST,
             "",
-            self::USER_PASSWORD_TEST,
-            self::USER_PHONE_TEST,
+            ConstHelper::USER_PASSWORD_TEST,
+            ConstHelper::USER_PHONE_TEST,
         );
         $exception = new InvalidRequestException(UserService::ERROR_EMPTY_USER_EMAIL);
         $errorMessage = ErrorMessage::generate($exception, $this->serializer);
@@ -252,10 +247,10 @@ class UserControllerTest extends KernelTestCase
     public function testCreateUserEmptyPassword(): void
     {
         $userCreate = new UserEditableDto(
-            self::USER_NAME_TEST,
-            self::USER_EMAIL_TEST,
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
             "",
-            self::USER_PHONE_TEST,
+            ConstHelper::USER_PHONE_TEST,
         );
         $exception = new InvalidRequestException(UserService::ERROR_EMPTY_USER_PASSWORD);
         $errorMessage = ErrorMessage::generate($exception, $this->serializer);
@@ -278,10 +273,10 @@ class UserControllerTest extends KernelTestCase
         $existingUser = $this->addUser();
 
         $userCreate = new UserEditableDto(
-            self::NEW_USER_NAME_TEST,
-            self::NEW_USER_EMAIL_TEST,
-            self::NEW_USER_PASSWORD_TEST,
-            self::NEW_USER_PHONE_TEST,
+            ConstHelper::NEW_USER_NAME_TEST,
+            ConstHelper::NEW_USER_EMAIL_TEST,
+            ConstHelper::NEW_USER_PASSWORD_TEST,
+            ConstHelper::NEW_USER_PHONE_TEST,
         );
 
         $userRepository = $this->entityManager->getRepository(User::class);
@@ -304,9 +299,9 @@ class UserControllerTest extends KernelTestCase
 
         $userCreate = new UserEditableDto(
             "",
-            self::NEW_USER_EMAIL_TEST,
-            self::NEW_USER_PASSWORD_TEST,
-            self::NEW_USER_PHONE_TEST,
+            ConstHelper::NEW_USER_EMAIL_TEST,
+            ConstHelper::NEW_USER_PASSWORD_TEST,
+            ConstHelper::NEW_USER_PHONE_TEST,
         );
         $exception = new InvalidRequestException(UserService::ERROR_EMPTY_USER_NAME);
         $errorMessage = ErrorMessage::generate($exception, $this->serializer);
@@ -331,10 +326,10 @@ class UserControllerTest extends KernelTestCase
         $existingUser = $this->addUser();
 
         $userCreate = new UserEditableDto(
-            self::NEW_USER_NAME_TEST,
+            ConstHelper::NEW_USER_NAME_TEST,
             "",
-            self::NEW_USER_PASSWORD_TEST,
-            self::NEW_USER_PHONE_TEST,
+            ConstHelper::NEW_USER_PASSWORD_TEST,
+            ConstHelper::NEW_USER_PHONE_TEST,
         );
         $exception = new InvalidRequestException(UserService::ERROR_EMPTY_USER_EMAIL);
         $errorMessage = ErrorMessage::generate($exception, $this->serializer);
@@ -357,10 +352,10 @@ class UserControllerTest extends KernelTestCase
     public function testUpdateUserNotFound(): void
     {
         $userCreate = new UserEditableDto(
-            self::NEW_USER_NAME_TEST,
-            self::NEW_USER_EMAIL_TEST,
-            self::NEW_USER_PASSWORD_TEST,
-            self::NEW_USER_PHONE_TEST,
+            ConstHelper::NEW_USER_NAME_TEST,
+            ConstHelper::NEW_USER_EMAIL_TEST,
+            ConstHelper::NEW_USER_PASSWORD_TEST,
+            ConstHelper::NEW_USER_PHONE_TEST,
         );
 
         $userRepository = $this->entityManager->getRepository(User::class);
@@ -386,10 +381,10 @@ class UserControllerTest extends KernelTestCase
 
     protected function addUser(): ?User {
         $user = new User(
-            self::USER_NAME_TEST,
-            self::USER_EMAIL_TEST,
-            self::USER_PASSWORD_TEST,
-            self::USER_PHONE_TEST,
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PASSWORD_TEST,
+            ConstHelper::USER_PHONE_TEST,
         );
         $user->setCreatedAt(new \DateTime());
         $user->setUpdatedAt(new \DateTime());

--- a/tests/Integration/Controller/UserControllerTest.php
+++ b/tests/Integration/Controller/UserControllerTest.php
@@ -103,6 +103,7 @@ class UserControllerTest extends KernelTestCase
     public function testFindUserByEmailSuccess(): void
     {
         $user = $this->addUser();
+        $userDto = UserMapper::entityToDto($user);
 
         $userRepository = $this->entityManager->getRepository(User::class);
         $userService = new UserService($userRepository);
@@ -113,7 +114,7 @@ class UserControllerTest extends KernelTestCase
         $response = $userController->findUserByEmail($request, $this->serializer);
 
         $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
-        $this->assertEquals($this->serializer->serialize($user, JsonEncoder::FORMAT), $response->getContent());
+        $this->assertEquals($this->serializer->serialize($userDto, JsonEncoder::FORMAT), $response->getContent());
 
         $this->removeUser($user);
     }

--- a/tests/Integration/Controller/UserControllerTest.php
+++ b/tests/Integration/Controller/UserControllerTest.php
@@ -7,6 +7,7 @@ use App\Controller\UserController;
 use App\Dto\UserEditableDto;
 use App\Entity\User;
 use App\Exception\InvalidRequestException;
+use App\Mapper\UserMapper;
 use App\Service\UserService;
 use App\Tests\Utils\RequestHelper;
 use Doctrine\ORM\EntityManager;
@@ -79,6 +80,7 @@ class UserControllerTest extends KernelTestCase
     public function testSingleUserSuccess(): void
     {
         $user = $this->addUser();
+        $userDto = UserMapper::entityToDto($user);
 
         $userRepository = $this->entityManager->getRepository(User::class);
         $userService = new UserService($userRepository);
@@ -87,7 +89,7 @@ class UserControllerTest extends KernelTestCase
         $response = $userController->singleUser($user->getId(), $this->serializer);
 
         $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
-        $this->assertEquals($this->serializer->serialize($user, JsonEncoder::FORMAT), $response->getContent());
+        $this->assertEquals($this->serializer->serialize($userDto, JsonEncoder::FORMAT), $response->getContent());
 
         $this->removeUser($user);
     }

--- a/tests/Integration/Controller/UserControllerTest.php
+++ b/tests/Integration/Controller/UserControllerTest.php
@@ -59,6 +59,7 @@ class UserControllerTest extends KernelTestCase
     public function testListUsersSuccess(): void
     {
         $user = $this->addUser();
+        $userDto = UserMapper::entityToDto($user);
 
         $userRepository = $this->entityManager->getRepository(User::class);
         $userService = new UserService($userRepository);
@@ -67,7 +68,7 @@ class UserControllerTest extends KernelTestCase
         $response = $userController->listUsers($this->serializer);
 
         $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
-        $this->assertEquals($this->serializer->serialize([$user], JsonEncoder::FORMAT), $response->getContent());
+        $this->assertEquals($this->serializer->serialize([$userDto], JsonEncoder::FORMAT), $response->getContent());
 
         $this->removeUser($user);
     }

--- a/tests/Integration/Repository/UserRepositoryTest.php
+++ b/tests/Integration/Repository/UserRepositoryTest.php
@@ -3,6 +3,7 @@
 namespace App\Tests\Integration\Repository;
 
 use App\Entity\User;
+use App\Tests\Utils\ConstHelper;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\ORM\EntityManager;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
@@ -11,11 +12,6 @@ use Symfony\Component\Console\Tester\CommandTester;
 
 class UserRepositoryTest extends KernelTestCase
 {
-    const USER_NAME_TEST = "name";
-    const USER_EMAIL_TEST = "email@domain.com";
-    const USER_PASSWORD_TEST = "password";
-    const USER_PHONE_TEST = "910123123";
-
     /**
      * @var EntityManager
      */
@@ -62,7 +58,7 @@ class UserRepositoryTest extends KernelTestCase
 
         $response = $this->entityManager
             ->getRepository(User::class)
-            ->findOneBy(['name' => self::USER_NAME_TEST])
+            ->findOneBy(['name' => ConstHelper::USER_NAME_TEST])
         ;
 
         $this->assertSame($user->getName(), $response->getName());
@@ -79,7 +75,7 @@ class UserRepositoryTest extends KernelTestCase
 
         $response = $this->entityManager
             ->getRepository(User::class)
-            ->findOneBy(['email' => self::USER_EMAIL_TEST])
+            ->findOneBy(['email' => ConstHelper::USER_EMAIL_TEST])
         ;
 
         $this->assertSame($user->getName(), $response->getName());
@@ -92,10 +88,10 @@ class UserRepositoryTest extends KernelTestCase
 
     public function testSaveUser() {
         $user = new User(
-            self::USER_NAME_TEST,
-            self::USER_EMAIL_TEST,
-            self::USER_PASSWORD_TEST,
-            self::USER_PHONE_TEST,
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PASSWORD_TEST,
+            ConstHelper::USER_PHONE_TEST,
         );
         $timestamp = new \DateTime();
         $user->setCreatedAt($timestamp);
@@ -127,10 +123,10 @@ class UserRepositoryTest extends KernelTestCase
 
     protected function addUser(): ?User {
         $user = new User(
-            self::USER_NAME_TEST,
-            self::USER_EMAIL_TEST,
-            self::USER_PASSWORD_TEST,
-            self::USER_PHONE_TEST,
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PASSWORD_TEST,
+            ConstHelper::USER_PHONE_TEST,
         );
         $user->setCreatedAt(new \DateTime());
         $user->setUpdatedAt(new \DateTime());

--- a/tests/Integration/Service/UserServiceTest.php
+++ b/tests/Integration/Service/UserServiceTest.php
@@ -165,10 +165,7 @@ class UserServiceTest extends KernelTestCase
 
         $this->assertEquals($userCreate->getName(), $response->getName());
         $this->assertEquals($userCreate->getEmail(), $response->getEmail());
-        $this->assertEquals($userCreate->getPassword(), $response->getPassword());
         $this->assertEquals($userCreate->getPhone(), $response->getPhone());
-
-        $this->removeUser($response);
     }
 
     public function testUpdateUserEmptyName(): void
@@ -187,9 +184,7 @@ class UserServiceTest extends KernelTestCase
 
         $this->expectException(InvalidRequestException::class);
 
-        $response = $userService->updateUser($existingUser->getId(), $userCreate);
-
-        $this->removeUser($response);
+        $userService->updateUser($existingUser->getId(), $userCreate);
     }
 
     public function testUpdateUserEmptyEmail(): void

--- a/tests/Integration/Service/UserServiceTest.php
+++ b/tests/Integration/Service/UserServiceTest.php
@@ -83,13 +83,14 @@ class UserServiceTest extends KernelTestCase
     public function testFindUserByEmailSuccess(): void
     {
         $user = $this->addUser();
+        $userDto = UserMapper::entityToDto($user);
 
         $userRepository = $this->entityManager->getRepository(User::class);
         $userService = new UserService($userRepository);
 
         $response = $userService->findUserByEmail($user->getEmail());
 
-        $this->assertEquals($user, $response);
+        $this->assertEquals($userDto, $response);
 
         $this->removeUser($user);
     }

--- a/tests/Integration/Service/UserServiceTest.php
+++ b/tests/Integration/Service/UserServiceTest.php
@@ -7,6 +7,7 @@ use App\Dto\UserEditableDto;
 use App\Entity\User;
 use App\Exception\InvalidRequestException;
 use App\Exception\UserNotFoundException;
+use App\Mapper\UserMapper;
 use App\Service\UserService;
 use Doctrine\ORM\EntityManager;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
@@ -62,13 +63,14 @@ class UserServiceTest extends KernelTestCase
     public function testFindUserSuccess(): void
     {
         $user = $this->addUser();
+        $userDto = UserMapper::entityToDto($user);
 
         $userRepository = $this->entityManager->getRepository(User::class);
         $userService = new UserService($userRepository);
 
         $response = $userService->findUser($user->getId());
 
-        $this->assertEquals($user, $response);
+        $this->assertEquals($userDto, $response);
 
         $this->removeUser($user);
     }

--- a/tests/Integration/Service/UserServiceTest.php
+++ b/tests/Integration/Service/UserServiceTest.php
@@ -144,10 +144,7 @@ class UserServiceTest extends KernelTestCase
 
         $this->assertEquals($userCreate->getName(), $response->getName());
         $this->assertEquals($userCreate->getEmail(), $response->getEmail());
-        $this->assertEquals($userCreate->getPassword(), $response->getPassword());
         $this->assertEquals($userCreate->getPhone(), $response->getPhone());
-
-        $this->removeUser($response);
     }
 
     public function testUpdateUserSuccess(): void

--- a/tests/Integration/Service/UserServiceTest.php
+++ b/tests/Integration/Service/UserServiceTest.php
@@ -9,6 +9,7 @@ use App\Exception\InvalidRequestException;
 use App\Exception\UserNotFoundException;
 use App\Mapper\UserMapper;
 use App\Service\UserService;
+use App\Tests\Utils\ConstHelper;
 use Doctrine\ORM\EntityManager;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
@@ -16,14 +17,6 @@ use Symfony\Component\Console\Tester\CommandTester;
 
 class UserServiceTest extends KernelTestCase
 {
-    const USER_NAME_TEST = "name";
-    const USER_EMAIL_TEST = "email@domain.com";
-    const USER_PASSWORD_TEST = "password";
-    const USER_PHONE_TEST = "910123123";
-    const NEW_USER_NAME_TEST = "new name";
-    const NEW_USER_EMAIL_TEST = "new_email@domain.com";
-    const NEW_USER_PASSWORD_TEST = "password";
-    const NEW_USER_PHONE_TEST = "910123123";
     /**
      * @var EntityManager
      */
@@ -108,7 +101,7 @@ class UserServiceTest extends KernelTestCase
 
         $this->expectException(UserNotFoundException::class);
 
-        $userService->findUserByEmail(self::USER_EMAIL_TEST);
+        $userService->findUserByEmail(ConstHelper::USER_EMAIL_TEST);
     }
 
     public function testRemoveUserSuccess(): void
@@ -136,10 +129,10 @@ class UserServiceTest extends KernelTestCase
     public function testCreateUserSuccess(): void
     {
         $userCreate = new UserEditableDto(
-            self::USER_NAME_TEST,
-            self::USER_EMAIL_TEST,
-            self::USER_PASSWORD_TEST,
-            self::USER_PHONE_TEST,
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PASSWORD_TEST,
+            ConstHelper::USER_PHONE_TEST,
         );
 
         $userRepository = $this->entityManager->getRepository(User::class);
@@ -160,10 +153,10 @@ class UserServiceTest extends KernelTestCase
         $existingUser = $this->addUser();
 
         $userCreate = new UserEditableDto(
-            self::NEW_USER_NAME_TEST,
-            self::NEW_USER_EMAIL_TEST,
-            self::NEW_USER_PASSWORD_TEST,
-            self::NEW_USER_PHONE_TEST,
+            ConstHelper::NEW_USER_NAME_TEST,
+            ConstHelper::NEW_USER_EMAIL_TEST,
+            ConstHelper::NEW_USER_PASSWORD_TEST,
+            ConstHelper::NEW_USER_PHONE_TEST,
         );
 
         $userRepository = $this->entityManager->getRepository(User::class);
@@ -185,9 +178,9 @@ class UserServiceTest extends KernelTestCase
 
         $userCreate = new UserEditableDto(
             "",
-            self::NEW_USER_EMAIL_TEST,
-            self::NEW_USER_PASSWORD_TEST,
-            self::NEW_USER_PHONE_TEST,
+            ConstHelper::NEW_USER_EMAIL_TEST,
+            ConstHelper::NEW_USER_PASSWORD_TEST,
+            ConstHelper::NEW_USER_PHONE_TEST,
         );
 
         $userRepository = $this->entityManager->getRepository(User::class);
@@ -205,10 +198,10 @@ class UserServiceTest extends KernelTestCase
         $existingUser = $this->addUser();
 
         $userCreate = new UserEditableDto(
-            self::NEW_USER_NAME_TEST,
+            ConstHelper::NEW_USER_NAME_TEST,
             "",
-            self::NEW_USER_PASSWORD_TEST,
-            self::NEW_USER_PHONE_TEST,
+            ConstHelper::NEW_USER_PASSWORD_TEST,
+            ConstHelper::NEW_USER_PHONE_TEST,
         );
 
         $userRepository = $this->entityManager->getRepository(User::class);
@@ -251,10 +244,10 @@ class UserServiceTest extends KernelTestCase
 
     protected function addUser(): ?User {
         $user = new User(
-            self::USER_NAME_TEST,
-            self::USER_EMAIL_TEST,
-            self::USER_PASSWORD_TEST,
-            self::USER_PHONE_TEST,
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PASSWORD_TEST,
+            ConstHelper::USER_PHONE_TEST,
         );
         $user->setCreatedAt(new \DateTime());
         $user->setUpdatedAt(new \DateTime());

--- a/tests/Integration/Service/UserServiceTest.php
+++ b/tests/Integration/Service/UserServiceTest.php
@@ -42,13 +42,14 @@ class UserServiceTest extends KernelTestCase
     public function testListUsersSuccess(): void
     {
         $user = $this->addUser();
+        $userDto = UserMapper::entityToDto($user);
 
         $userRepository = $this->entityManager->getRepository(User::class);
         $userService = new UserService($userRepository);
 
         $response = $userService->findAllUsers();
 
-        $this->assertEquals([$user], $response);
+        $this->assertEquals([$userDto], $response);
 
         $this->removeUser($user);
     }

--- a/tests/Unit/Controller/UserControllerTest.php
+++ b/tests/Unit/Controller/UserControllerTest.php
@@ -6,7 +6,6 @@ use App\Common\ErrorMessage;
 use App\Controller\UserController;
 use App\Dto\UserDto;
 use App\Dto\UserEditableDto;
-use App\Entity\User;
 use App\Exception\InvalidRequestException;
 use App\Exception\UserNotFoundException;
 use App\Service\UserService;
@@ -284,33 +283,31 @@ class UserControllerTest extends TestCase
 
     public function testUpdateUserSuccess(): void
     {
-        $userId = 1;
         $userCreate = new UserEditableDto(
             ConstHelper::USER_NAME_TEST,
             ConstHelper::USER_EMAIL_TEST,
             ConstHelper::USER_PASSWORD_TEST,
             ConstHelper::USER_PHONE_TEST,
         );
-        $user = new User(
+        $userDto = new UserDto(
+            ConstHelper::USER_ID_TEST,
             ConstHelper::USER_NAME_TEST,
             ConstHelper::USER_EMAIL_TEST,
-            ConstHelper::USER_PASSWORD_TEST,
             ConstHelper::USER_PHONE_TEST,
         );
-
         $userService = $this->createMock(UserService::class);
         $userService->expects(self::once())
             ->method('updateUser')
-            ->willReturn($user);
+            ->willReturn($userDto);
         $userController = new UserController($userService);
 
         $content = $this->serializer->serialize($userCreate, JsonEncoder::FORMAT);
         $request = $this->createRequest("users/1", Request::METHOD_PUT, $content);
 
-        $response = $userController->updateUser($userId, $request, $this->serializer);
+        $response = $userController->updateUser(ConstHelper::USER_ID_TEST, $request, $this->serializer);
 
         $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
-        $this->assertEquals($this->serializer->serialize($user, JsonEncoder::FORMAT), $response->getContent());
+        $this->assertEquals($this->serializer->serialize($userDto, JsonEncoder::FORMAT), $response->getContent());
     }
 
     public function testUpdateUserNotfound(): void

--- a/tests/Unit/Controller/UserControllerTest.php
+++ b/tests/Unit/Controller/UserControllerTest.php
@@ -9,7 +9,6 @@ use App\Dto\UserEditableDto;
 use App\Entity\User;
 use App\Exception\InvalidRequestException;
 use App\Exception\UserNotFoundException;
-use App\Mapper\UserMapper;
 use App\Service\UserService;
 use App\Service\UserServiceInterface;
 use App\Tests\Utils\ConstHelper;
@@ -38,6 +37,7 @@ class UserControllerTest extends TestCase
     public function testListUsersSuccess(): void
     {
         $userDto = new UserDto(
+            ConstHelper::USER_ID_TEST,
             ConstHelper::USER_NAME_TEST,
             ConstHelper::USER_EMAIL_TEST,
             ConstHelper::USER_PHONE_TEST,
@@ -61,6 +61,7 @@ class UserControllerTest extends TestCase
     {
         $userId = 1;
         $userDto = new UserDto(
+            ConstHelper::USER_ID_TEST,
             ConstHelper::USER_NAME_TEST,
             ConstHelper::USER_EMAIL_TEST,
             ConstHelper::USER_PHONE_TEST,
@@ -97,6 +98,7 @@ class UserControllerTest extends TestCase
     public function testFindUserByEmailSuccess(): void
     {
         $userDto = new UserDto(
+            ConstHelper::USER_ID_TEST,
             ConstHelper::USER_NAME_TEST,
             ConstHelper::USER_EMAIL_TEST,
             ConstHelper::USER_PASSWORD_TEST,
@@ -198,17 +200,17 @@ class UserControllerTest extends TestCase
             ConstHelper::USER_PASSWORD_TEST,
             ConstHelper::USER_PHONE_TEST,
         );
-        $user = new User(
+        $userDto = new UserDto(
+            ConstHelper::USER_ID_TEST,
             ConstHelper::USER_NAME_TEST,
             ConstHelper::USER_EMAIL_TEST,
-            ConstHelper::USER_PASSWORD_TEST,
             ConstHelper::USER_PHONE_TEST,
         );
 
         $userService = $this->createMock(UserServiceInterface::class);
         $userService->expects(self::once())
             ->method('createUser')
-            ->willReturn($user);
+            ->willReturn($userDto);
         $userController = new UserController($userService);
 
         $content = $this->serializer->serialize($userCreate, JsonEncoder::FORMAT);
@@ -217,7 +219,7 @@ class UserControllerTest extends TestCase
         $response = $userController->createUser($request, $this->serializer);
 
         $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
-        $this->assertEquals($this->serializer->serialize($user, JsonEncoder::FORMAT), $response->getContent());
+        $this->assertEquals($this->serializer->serialize($userDto, JsonEncoder::FORMAT), $response->getContent());
     }
 
     public function testCreateUserInvalidBody(): void
@@ -236,12 +238,6 @@ class UserControllerTest extends TestCase
     {
         $userCreate = new UserEditableDto(
             "",
-            ConstHelper::USER_EMAIL_TEST,
-            ConstHelper::USER_PASSWORD_TEST,
-            ConstHelper::USER_PHONE_TEST,
-        );
-        $user = new User(
-            ConstHelper::USER_NAME_TEST,
             ConstHelper::USER_EMAIL_TEST,
             ConstHelper::USER_PASSWORD_TEST,
             ConstHelper::USER_PHONE_TEST,

--- a/tests/Unit/Controller/UserControllerTest.php
+++ b/tests/Unit/Controller/UserControllerTest.php
@@ -21,11 +21,9 @@ use Symfony\Component\Serializer\Serializer;
 
 class UserControllerTest extends TestCase
 {
-    const USER_NAME_TEST = "name";
-    const USER_EMAIL_TEST = "email@domain.com";
-    const USER_PASSWORD_TEST = "password";
-    const USER_PHONE_TEST = "910123123";
-
+    /**
+     * @var Serializer
+     */
     private Serializer $serializer;
 
     protected function setUp(): void
@@ -62,9 +60,9 @@ class UserControllerTest extends TestCase
     {
         $userId = 1;
         $userDto = new UserDto(
-            self::USER_NAME_TEST,
-            self::USER_EMAIL_TEST,
-            self::USER_PHONE_TEST,
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PHONE_TEST,
         );
 
         $userService = $this->createMock(UserServiceInterface::class);
@@ -98,10 +96,10 @@ class UserControllerTest extends TestCase
     public function testFindUserByEmailSuccess(): void
     {
         $user = new User(
-            self::USER_NAME_TEST,
-            self::USER_EMAIL_TEST,
-            self::USER_PASSWORD_TEST,
-            self::USER_PHONE_TEST,
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PASSWORD_TEST,
+            ConstHelper::USER_PHONE_TEST,
         );
 
         $userService = $this->createMock(UserServiceInterface::class);
@@ -110,7 +108,7 @@ class UserControllerTest extends TestCase
             ->willReturn($user);
         $userController = new UserController($userService);
 
-        $parameters = ["email" => self::USER_EMAIL_TEST];
+        $parameters = ["email" => ConstHelper::USER_EMAIL_TEST];
         $request = $this->createRequest("users/email", Request::METHOD_GET, "", $parameters);
 
         $response = $userController->findUserByEmail($request, $this->serializer);
@@ -134,20 +132,13 @@ class UserControllerTest extends TestCase
 
     public function testFindUserByEmailNotFound(): void
     {
-        $user = new User(
-            self::USER_NAME_TEST,
-            self::USER_EMAIL_TEST,
-            self::USER_PASSWORD_TEST,
-            self::USER_PHONE_TEST,
-        );
-
         $userService = $this->createMock(UserServiceInterface::class);
         $userService->expects(self::once())
             ->method('findUserByEmail')
-            ->willThrowException(new UserNotFoundException(self::USER_EMAIL_TEST));
+            ->willThrowException(new UserNotFoundException(ConstHelper::USER_EMAIL_TEST));
         $userController = new UserController($userService);
 
-        $parameters = ["email" => self::USER_EMAIL_TEST];
+        $parameters = ["email" => ConstHelper::USER_EMAIL_TEST];
         $request = $this->createRequest("users/email", Request::METHOD_GET, "", $parameters);
 
         $response = $userController->findUserByEmail($request, $this->serializer);
@@ -202,16 +193,16 @@ class UserControllerTest extends TestCase
     public function testCreateUserSuccess(): void
     {
         $userCreate = new UserEditableDto(
-            self::USER_NAME_TEST,
-            self::USER_EMAIL_TEST,
-            self::USER_PASSWORD_TEST,
-            self::USER_PHONE_TEST,
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PASSWORD_TEST,
+            ConstHelper::USER_PHONE_TEST,
         );
         $user = new User(
-            self::USER_NAME_TEST,
-            self::USER_EMAIL_TEST,
-            self::USER_PASSWORD_TEST,
-            self::USER_PHONE_TEST,
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PASSWORD_TEST,
+            ConstHelper::USER_PHONE_TEST,
         );
 
         $userService = $this->createMock(UserServiceInterface::class);
@@ -245,15 +236,15 @@ class UserControllerTest extends TestCase
     {
         $userCreate = new UserEditableDto(
             "",
-            self::USER_EMAIL_TEST,
-            self::USER_PASSWORD_TEST,
-            self::USER_PHONE_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PASSWORD_TEST,
+            ConstHelper::USER_PHONE_TEST,
         );
         $user = new User(
-            self::USER_NAME_TEST,
-            self::USER_EMAIL_TEST,
-            self::USER_PASSWORD_TEST,
-            self::USER_PHONE_TEST,
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PASSWORD_TEST,
+            ConstHelper::USER_PHONE_TEST,
         );
         $expectedException = new InvalidRequestException("request");
 
@@ -275,10 +266,10 @@ class UserControllerTest extends TestCase
     public function testCreateUserRepositoryError(): void
     {
         $userCreate = new UserEditableDto(
-            self::USER_NAME_TEST,
-            self::USER_EMAIL_TEST,
-            self::USER_PASSWORD_TEST,
-            self::USER_PHONE_TEST,
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PASSWORD_TEST,
+            ConstHelper::USER_PHONE_TEST,
         );
 
         $userService = $this->createMock(UserServiceInterface::class);
@@ -299,16 +290,16 @@ class UserControllerTest extends TestCase
     {
         $userId = 1;
         $userCreate = new UserEditableDto(
-            self::USER_NAME_TEST,
-            self::USER_EMAIL_TEST,
-            self::USER_PASSWORD_TEST,
-            self::USER_PHONE_TEST,
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PASSWORD_TEST,
+            ConstHelper::USER_PHONE_TEST,
         );
         $user = new User(
-            self::USER_NAME_TEST,
-            self::USER_EMAIL_TEST,
-            self::USER_PASSWORD_TEST,
-            self::USER_PHONE_TEST,
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PASSWORD_TEST,
+            ConstHelper::USER_PHONE_TEST,
         );
 
         $userService = $this->createMock(UserService::class);
@@ -330,10 +321,10 @@ class UserControllerTest extends TestCase
     {
         $userId = 1;
         $userCreate = new UserEditableDto(
-            self::USER_NAME_TEST,
-            self::USER_EMAIL_TEST,
-            self::USER_PASSWORD_TEST,
-            self::USER_PHONE_TEST,
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PASSWORD_TEST,
+            ConstHelper::USER_PHONE_TEST,
         );
 
         $userService = $this->createMock(UserServiceInterface::class);
@@ -354,10 +345,10 @@ class UserControllerTest extends TestCase
     {
         $userId = 1;
         $userCreate = new UserEditableDto(
-            self::USER_NAME_TEST,
-            self::USER_EMAIL_TEST,
-            self::USER_PASSWORD_TEST,
-            self::USER_PHONE_TEST,
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PASSWORD_TEST,
+            ConstHelper::USER_PHONE_TEST,
         );
 
         $userService = $this->createMock(UserServiceInterface::class);

--- a/tests/Unit/Controller/UserControllerTest.php
+++ b/tests/Unit/Controller/UserControllerTest.php
@@ -4,12 +4,14 @@ namespace App\Tests\Unit\Controller;
 
 use App\Common\ErrorMessage;
 use App\Controller\UserController;
+use App\Dto\UserDto;
 use App\Dto\UserEditableDto;
 use App\Entity\User;
 use App\Exception\InvalidRequestException;
 use App\Exception\UserNotFoundException;
 use App\Service\UserService;
 use App\Service\UserServiceInterface;
+use App\Tests\Utils\ConstHelper;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -36,47 +38,45 @@ class UserControllerTest extends TestCase
 
     public function testListUsersSuccess(): void
     {
-        $user = new User(
-            self::USER_NAME_TEST,
-            self::USER_EMAIL_TEST,
-            self::USER_PASSWORD_TEST,
-            self::USER_PHONE_TEST,
+        $userDto = new UserDto(
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PHONE_TEST,
         );
 
         $userService = $this->createMock(UserServiceInterface::class);
         $userService->expects(self::once())
             ->method('findAllUsers')
             ->willReturn([
-                $user
+                $userDto
             ]);
         $userController = new UserController($userService);
 
         $response = $userController->listUsers($this->serializer);
 
         $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
-        $this->assertEquals($this->serializer->serialize([$user], JsonEncoder::FORMAT), $response->getContent());
+        $this->assertEquals($this->serializer->serialize([$userDto], JsonEncoder::FORMAT), $response->getContent());
     }
 
     public function testSingleUserSuccess(): void
     {
         $userId = 1;
-        $user = new User(
+        $userDto = new UserDto(
             self::USER_NAME_TEST,
             self::USER_EMAIL_TEST,
-            self::USER_PASSWORD_TEST,
             self::USER_PHONE_TEST,
         );
 
         $userService = $this->createMock(UserServiceInterface::class);
         $userService->expects(self::once())
             ->method('findUser')
-            ->willReturn($user);
+            ->willReturn($userDto);
         $userController = new UserController($userService);
 
         $response = $userController->singleUser($userId, $this->serializer);
 
         $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
-        $this->assertEquals($this->serializer->serialize($user, JsonEncoder::FORMAT), $response->getContent());
+        $this->assertEquals($this->serializer->serialize($userDto, JsonEncoder::FORMAT), $response->getContent());
     }
 
     public function testSingleUserNotFound(): void
@@ -87,6 +87,7 @@ class UserControllerTest extends TestCase
         $userService->expects(self::once())
             ->method('findUser')
             ->willThrowException(new UserNotFoundException($userId));
+
         $userController = new UserController($userService);
 
         $response = $userController->singleUser($userId, $this->serializer);

--- a/tests/Unit/Controller/UserControllerTest.php
+++ b/tests/Unit/Controller/UserControllerTest.php
@@ -9,6 +9,7 @@ use App\Dto\UserEditableDto;
 use App\Entity\User;
 use App\Exception\InvalidRequestException;
 use App\Exception\UserNotFoundException;
+use App\Mapper\UserMapper;
 use App\Service\UserService;
 use App\Service\UserServiceInterface;
 use App\Tests\Utils\ConstHelper;
@@ -95,17 +96,16 @@ class UserControllerTest extends TestCase
 
     public function testFindUserByEmailSuccess(): void
     {
-        $user = new User(
+        $userDto = new UserDto(
             ConstHelper::USER_NAME_TEST,
             ConstHelper::USER_EMAIL_TEST,
             ConstHelper::USER_PASSWORD_TEST,
-            ConstHelper::USER_PHONE_TEST,
         );
 
         $userService = $this->createMock(UserServiceInterface::class);
         $userService->expects(self::once())
             ->method('findUserByEmail')
-            ->willReturn($user);
+            ->willReturn($userDto);
         $userController = new UserController($userService);
 
         $parameters = ["email" => ConstHelper::USER_EMAIL_TEST];
@@ -114,7 +114,7 @@ class UserControllerTest extends TestCase
         $response = $userController->findUserByEmail($request, $this->serializer);
 
         $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
-        $this->assertEquals($this->serializer->serialize($user, JsonEncoder::FORMAT), $response->getContent());
+        $this->assertEquals($this->serializer->serialize($userDto, JsonEncoder::FORMAT), $response->getContent());
     }
 
     public function testFindUserByEmailEmptyEmail(): void

--- a/tests/Unit/Dto/UserDtoTest.php
+++ b/tests/Unit/Dto/UserDtoTest.php
@@ -3,7 +3,6 @@
 namespace App\Tests\Unit\Dto;
 
 use App\DTO\UserDTO;
-use App\Dto\UserEditableDto;
 use App\Tests\Utils\ConstHelper;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Unit/Dto/UserDtoTest.php
+++ b/tests/Unit/Dto/UserDtoTest.php
@@ -11,14 +11,17 @@ class UserDtoTest extends TestCase{
         $timestamp = new \DateTime();
 
         $user = new UserDto(
+            ConstHelper::USER_ID_TEST,
             ConstHelper::USER_NAME_TEST,
             ConstHelper::USER_EMAIL_TEST,
             ConstHelper::USER_PHONE_TEST,
             $timestamp,
             $timestamp,
         );
+        $user->setId(ConstHelper::USER_ID_TEST);
 
         $this->assertIsObject($user);
+        $this->assertEquals(ConstHelper::USER_ID_TEST, $user->getId());
         $this->assertEquals(ConstHelper::USER_NAME_TEST, $user->getName());
         $this->assertEquals(ConstHelper::USER_EMAIL_TEST, $user->getEmail());
         $this->assertEquals(ConstHelper::USER_PHONE_TEST, $user->getPhone());
@@ -26,8 +29,23 @@ class UserDtoTest extends TestCase{
         $this->assertEquals($timestamp, $user->getUpdatedAt());
     }
 
+    public function testUserDtoId() {
+        $user = new UserDto(
+            ConstHelper::USER_ID_TEST,
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PHONE_TEST,
+        );
+
+        $user->setId(ConstHelper::NEW_USER_ID_TEST);
+
+        $this->assertIsObject($user);
+        $this->assertEquals(ConstHelper::NEW_USER_ID_TEST, $user->getId());
+    }
+
     public function testUserDtoName() {
         $user = new UserDto(
+            ConstHelper::USER_ID_TEST,
             ConstHelper::USER_NAME_TEST,
             ConstHelper::USER_EMAIL_TEST,
             ConstHelper::USER_PHONE_TEST,
@@ -41,6 +59,7 @@ class UserDtoTest extends TestCase{
 
     public function testUserDtoEmail() {
         $user = new UserDto(
+            ConstHelper::USER_ID_TEST,
             ConstHelper::USER_NAME_TEST,
             ConstHelper::USER_EMAIL_TEST,
             ConstHelper::USER_PHONE_TEST,
@@ -54,6 +73,7 @@ class UserDtoTest extends TestCase{
 
     public function testUserDtoPhone() {
         $user = new UserDto(
+            ConstHelper::USER_ID_TEST,
             ConstHelper::USER_NAME_TEST,
             ConstHelper::USER_EMAIL_TEST,
             ConstHelper::USER_PHONE_TEST,
@@ -67,6 +87,7 @@ class UserDtoTest extends TestCase{
 
     public function testUserDtoCreatedAt() {
         $user = new UserDto(
+            ConstHelper::USER_ID_TEST,
             ConstHelper::USER_NAME_TEST,
             ConstHelper::USER_EMAIL_TEST,
             ConstHelper::USER_PHONE_TEST,
@@ -81,6 +102,7 @@ class UserDtoTest extends TestCase{
 
     public function testUserDtoUpdatedAt() {
         $user = new UserDto(
+            ConstHelper::USER_ID_TEST,
             ConstHelper::USER_NAME_TEST,
             ConstHelper::USER_EMAIL_TEST,
             ConstHelper::USER_PHONE_TEST,

--- a/tests/Unit/Dto/UserDtoTest.php
+++ b/tests/Unit/Dto/UserDtoTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace App\Tests\Unit\Dto;
+
+use App\DTO\UserDTO;
+use App\Dto\UserEditableDto;
+use App\Tests\Utils\ConstHelper;
+use PHPUnit\Framework\TestCase;
+
+class UserDtoTest extends TestCase{
+    public function testUserDtoConstruct() {
+        $timestamp = new \DateTime();
+
+        $user = new UserDto(
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PHONE_TEST,
+            $timestamp,
+            $timestamp,
+        );
+
+        $this->assertIsObject($user);
+        $this->assertEquals(ConstHelper::USER_NAME_TEST, $user->getName());
+        $this->assertEquals(ConstHelper::USER_EMAIL_TEST, $user->getEmail());
+        $this->assertEquals(ConstHelper::USER_PHONE_TEST, $user->getPhone());
+        $this->assertEquals($timestamp, $user->getCreatedAt());
+        $this->assertEquals($timestamp, $user->getUpdatedAt());
+    }
+
+    public function testUserDtoName() {
+        $user = new UserDto(
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PHONE_TEST,
+        );
+
+        $user->setName(ConstHelper::NEW_USER_NAME_TEST);
+
+        $this->assertIsObject($user);
+        $this->assertEquals(ConstHelper::NEW_USER_NAME_TEST, $user->getName());
+    }
+
+    public function testUserDtoEmail() {
+        $user = new UserDto(
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PHONE_TEST,
+        );
+
+        $user->setEmail(ConstHelper::NEW_USER_EMAIL_TEST);
+
+        $this->assertIsObject($user);
+        $this->assertEquals(ConstHelper::NEW_USER_EMAIL_TEST, $user->getEmail());
+    }
+
+    public function testUserDtoPhone() {
+        $user = new UserDto(
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PHONE_TEST,
+        );
+
+        $user->setPhone(ConstHelper::NEW_USER_PHONE_TEST);
+
+        $this->assertIsObject($user);
+        $this->assertEquals(ConstHelper::NEW_USER_PHONE_TEST, $user->getPhone());
+    }
+
+    public function testUserDtoCreatedAt() {
+        $user = new UserDto(
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PHONE_TEST,
+        );
+        $timestamp = new \DateTime();
+
+        $user->setCreatedAt($timestamp);
+
+        $this->assertIsObject($user);
+        $this->assertEquals($timestamp, $user->getCreatedAt());
+    }
+
+    public function testUserDtoUpdatedAt() {
+        $user = new UserDto(
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PHONE_TEST,
+        );
+        $timestamp = new \DateTime();
+
+        $user->setUpdatedAt($timestamp);
+
+        $this->assertIsObject($user);
+        $this->assertEquals($timestamp, $user->getUpdatedAt());
+    }
+}

--- a/tests/Unit/Entity/UserTest.php
+++ b/tests/Unit/Entity/UserTest.php
@@ -22,6 +22,14 @@ class UserTest extends TestCase{
         $this->assertEquals(ConstHelper::USER_PHONE_TEST, $user->getPhone());
     }
 
+    public function testUserId() {
+        $user = new User("", "", "", "");
+
+        $user->setId(ConstHelper::USER_ID_TEST);
+
+        $this->assertEquals(ConstHelper::USER_ID_TEST, $user->getId());
+    }
+
     public function testUserName() {
         $user = new User("", "", "", "");
 

--- a/tests/Unit/Entity/UserTest.php
+++ b/tests/Unit/Entity/UserTest.php
@@ -3,57 +3,58 @@
 namespace App\Tests\Unit\Entity;
 
 use App\Entity\User;
+use App\Tests\Utils\ConstHelper;
 use PHPUnit\Framework\TestCase;
 
 class UserTest extends TestCase{
-    const USER_NAME_TEST = "name";
-    const USER_EMAIL_TEST = "email@domain.com";
-    const USER_PASSWORD_TEST = "password";
-    const USER_PHONE_TEST = "910123123";
-
     public function testUserCreate() {
-        $user = new User(self::USER_NAME_TEST, self::USER_EMAIL_TEST, self::USER_PASSWORD_TEST, self::USER_PHONE_TEST);
+        $user = new User(
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PASSWORD_TEST,
+            ConstHelper::USER_PHONE_TEST,
+        );
 
         $this->assertIsObject($user);
-        $this->assertEquals(self::USER_NAME_TEST, $user->getName());
-        $this->assertEquals(self::USER_EMAIL_TEST, $user->getEmail());
-        $this->assertEquals(self::USER_PASSWORD_TEST, $user->getPassword());
-        $this->assertEquals(self::USER_PHONE_TEST, $user->getPhone());
+        $this->assertEquals(ConstHelper::USER_NAME_TEST, $user->getName());
+        $this->assertEquals(ConstHelper::USER_EMAIL_TEST, $user->getEmail());
+        $this->assertEquals(ConstHelper::USER_PASSWORD_TEST, $user->getPassword());
+        $this->assertEquals(ConstHelper::USER_PHONE_TEST, $user->getPhone());
     }
 
     public function testUserName() {
-        $user = new User("test", "test", "test", "test");
+        $user = new User("", "", "", "");
 
-        $user->setName(self::USER_NAME_TEST);
+        $user->setName(ConstHelper::USER_NAME_TEST);
 
-        $this->assertEquals(self::USER_NAME_TEST, $user->getName());
+        $this->assertEquals(ConstHelper::USER_NAME_TEST, $user->getName());
     }
 
     public function testUserEmail() {
-        $user = new User("test", "test", "test", "test");
+        $user = new User("", "", "", "");
 
-        $user->setEmail(self::USER_EMAIL_TEST);
+        $user->setEmail(ConstHelper::USER_EMAIL_TEST);
 
-        $this->assertEquals(self::USER_EMAIL_TEST, $user->getEmail());    }
+        $this->assertEquals(ConstHelper::USER_EMAIL_TEST, $user->getEmail());    }
 
     public function testUserPassword() {
-        $user = new User("test", "test", "test", "test");
+        $user = new User("", "", "", "");
 
-        $user->setPassword(self::USER_PASSWORD_TEST);
+        $user->setPassword(ConstHelper::USER_PASSWORD_TEST);
 
-        $this->assertEquals(self::USER_PASSWORD_TEST, $user->getPassword());
+        $this->assertEquals(ConstHelper::USER_PASSWORD_TEST, $user->getPassword());
     }
 
     public function testUserPhone() {
-        $user = new User("test", "test", "test", "test");
+        $user = new User("", "", "", "");
 
-        $user->setPhone(self::USER_PHONE_TEST);
+        $user->setPhone(ConstHelper::USER_PHONE_TEST);
 
-        $this->assertEquals(self::USER_PHONE_TEST, $user->getPhone());
+        $this->assertEquals(ConstHelper::USER_PHONE_TEST, $user->getPhone());
     }
 
     public function testUserCreatedAt() {
-        $user = new User("test", "test", "test", "test");
+        $user = new User("", "", "", "");
 
         $createdAt = new \DateTime();
 
@@ -63,7 +64,7 @@ class UserTest extends TestCase{
     }
 
     public function testUserUpdatedAt() {
-        $user = new User("test", "test", "test", "test");
+        $user = new User("", "", "", "");
 
         $updatedAt = new \DateTime();
 

--- a/tests/Unit/Mapper/UserMapperTest.php
+++ b/tests/Unit/Mapper/UserMapperTest.php
@@ -16,6 +16,7 @@ class UserMapperTest extends TestCase{
             ConstHelper::USER_PASSWORD_TEST,
             ConstHelper::USER_PHONE_TEST,
         );
+        $user->setId(ConstHelper::USER_ID_TEST);
 
         $dto = UserMapper::entityToDto($user);
 
@@ -33,6 +34,7 @@ class UserMapperTest extends TestCase{
             ConstHelper::USER_PASSWORD_TEST,
             ConstHelper::USER_PHONE_TEST,
         );
+        $user->setId(ConstHelper::USER_ID_TEST);
         $users[] = $user;
 
         $dto = UserMapper::entityToDtoArray($users);

--- a/tests/Unit/Mapper/UserMapperTest.php
+++ b/tests/Unit/Mapper/UserMapperTest.php
@@ -2,6 +2,7 @@
 
 namespace App\Tests\Unit\Mapper;
 
+use App\Dto\UserEditableDto;
 use App\Entity\User;
 use App\Mapper\UserMapper;
 use App\Tests\Utils\ConstHelper;
@@ -16,7 +17,7 @@ class UserMapperTest extends TestCase{
             ConstHelper::USER_PHONE_TEST,
         );
 
-        $dto = UserMapper::EntityToDto($user);
+        $dto = UserMapper::entityToDto($user);
 
         $this->assertEquals($user->getName(), $dto->getName());
         $this->assertEquals($user->getEmail(), $dto->getEmail());
@@ -34,7 +35,7 @@ class UserMapperTest extends TestCase{
         );
         $users[] = $user;
 
-        $dto = UserMapper::EntityToDtoArray($users);
+        $dto = UserMapper::entityToDtoArray($users);
 
         $this->assertNotEmpty($dto);
         $this->assertEquals($user->getName(), $dto[0]->getName());
@@ -42,5 +43,21 @@ class UserMapperTest extends TestCase{
         $this->assertEquals($user->getPhone(), $dto[0]->getPhone());
         $this->assertEquals($user->getCreatedAt(), $dto[0]->getCreatedAt());
         $this->assertEquals($user->getUpdatedAt(), $dto[0]->getUpdatedAt());
+    }
+
+    public function testUserEditableDtoToEntity() {
+        $editableUser = new UserEditableDto(
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PASSWORD_TEST,
+            ConstHelper::USER_PHONE_TEST,
+        );
+
+        $user = UserMapper::userEditableDtoToEntity($editableUser);
+
+        $this->assertEquals($editableUser->getName(), $user->getName());
+        $this->assertEquals($editableUser->getEmail(), $user->getEmail());
+        $this->assertEquals($editableUser->getPassword(), $user->getPassword());
+        $this->assertEquals($editableUser->getPhone(), $user->getPhone());
     }
 }

--- a/tests/Unit/Mapper/UserMapperTest.php
+++ b/tests/Unit/Mapper/UserMapperTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Tests\Unit\Mapper;
+
+use App\Entity\User;
+use App\Mapper\UserMapper;
+use App\Tests\Utils\ConstHelper;
+use PHPUnit\Framework\TestCase;
+
+class UserMapperTest extends TestCase{
+    public function testEntityToDto() {
+        $user = new User(
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PASSWORD_TEST,
+            ConstHelper::USER_PHONE_TEST,
+        );
+
+        $dto = UserMapper::EntityToDto($user);
+
+        $this->assertEquals($user->getName(), $dto->getName());
+        $this->assertEquals($user->getEmail(), $dto->getEmail());
+        $this->assertEquals($user->getPhone(), $dto->getPhone());
+        $this->assertEquals($user->getCreatedAt(), $dto->getCreatedAt());
+        $this->assertEquals($user->getUpdatedAt(), $dto->getUpdatedAt());
+    }
+
+    public function testEntityToDtoArray() {
+        $user = new User(
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PASSWORD_TEST,
+            ConstHelper::USER_PHONE_TEST,
+        );
+        $users[] = $user;
+
+        $dto = UserMapper::EntityToDtoArray($users);
+
+        $this->assertNotEmpty($dto);
+        $this->assertEquals($user->getName(), $dto[0]->getName());
+        $this->assertEquals($user->getEmail(), $dto[0]->getEmail());
+        $this->assertEquals($user->getPhone(), $dto[0]->getPhone());
+        $this->assertEquals($user->getCreatedAt(), $dto[0]->getCreatedAt());
+        $this->assertEquals($user->getUpdatedAt(), $dto[0]->getUpdatedAt());
+    }
+}

--- a/tests/Unit/Service/UserServiceTest.php
+++ b/tests/Unit/Service/UserServiceTest.php
@@ -2,7 +2,6 @@
 
 namespace App\Tests\Unit\Service;
 
-use App\Dto\UserDto;
 use App\Dto\UserEditableDto;
 use App\Entity\User;
 use App\Exception\InvalidRequestException;

--- a/tests/Unit/Service/UserServiceTest.php
+++ b/tests/Unit/Service/UserServiceTest.php
@@ -6,27 +6,25 @@ use App\Dto\UserEditableDto;
 use App\Entity\User;
 use App\Exception\InvalidRequestException;
 use App\Exception\UserNotFoundException;
+use App\Mapper\UserMapper;
 use App\Repository\UserRepository;
 use App\Service\UserService;
+use App\Tests\Utils\ConstHelper;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 
 class UserServiceTest extends TestCase
 {
-    const USER_NAME_TEST = "name";
-    const USER_EMAIL_TEST = "email@domain.com";
-    const USER_PASSWORD_TEST = "password";
-    const USER_PHONE_TEST = "910123123";
-
     public function testFindUserSuccess(): void
     {
         $userId = 1;
         $user = new User(
-            self::USER_NAME_TEST,
-            self::USER_EMAIL_TEST,
-            self::USER_PASSWORD_TEST,
-            self::USER_PHONE_TEST,
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PASSWORD_TEST,
+            ConstHelper::USER_PHONE_TEST,
         );
+        $userDto = UserMapper::entityToDto($user);
 
         $userRepository = $this->createMock(UserRepository::class);
         $userRepository->expects(self::once())
@@ -37,7 +35,7 @@ class UserServiceTest extends TestCase
 
         $response = $userService->findUser($userId);
 
-        $this->assertEquals($user, $response);
+        $this->assertEquals($userDto, $response);
     }
 
     public function testFindUserNotFound(): void
@@ -75,10 +73,10 @@ class UserServiceTest extends TestCase
     public function testFindAllUsersSuccess(): void
     {
         $user = new User(
-            self::USER_NAME_TEST,
-            self::USER_EMAIL_TEST,
-            self::USER_PASSWORD_TEST,
-            self::USER_PHONE_TEST,
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PASSWORD_TEST,
+            ConstHelper::USER_PHONE_TEST,
         );
 
         $userRepository = $this->createMock(UserRepository::class);
@@ -111,10 +109,10 @@ class UserServiceTest extends TestCase
     {
         $userId = 1;
         $user = new User(
-            self::USER_NAME_TEST,
-            self::USER_EMAIL_TEST,
-            self::USER_PASSWORD_TEST,
-            self::USER_PHONE_TEST,
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PASSWORD_TEST,
+            ConstHelper::USER_PHONE_TEST,
         );
 
         $userRepository = $this->createMock(UserRepository::class);
@@ -132,10 +130,10 @@ class UserServiceTest extends TestCase
     {
         $userId = 1;
         $user = new User(
-            self::USER_NAME_TEST,
-            self::USER_EMAIL_TEST,
-            self::USER_PASSWORD_TEST,
-            self::USER_PHONE_TEST,
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PASSWORD_TEST,
+            ConstHelper::USER_PHONE_TEST,
         );
 
         $userRepository = $this->createMock(UserRepository::class);
@@ -157,10 +155,10 @@ class UserServiceTest extends TestCase
     {
         $userId = 1;
         $user = new User(
-            self::USER_NAME_TEST,
-            self::USER_EMAIL_TEST,
-            self::USER_PASSWORD_TEST,
-            self::USER_PHONE_TEST,
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PASSWORD_TEST,
+            ConstHelper::USER_PHONE_TEST,
         );
 
         $userRepository = $this->createMock(UserRepository::class);
@@ -181,16 +179,16 @@ class UserServiceTest extends TestCase
     public function testCreateUserSuccess(): void
     {
         $userCreate = new UserEditableDto(
-            self::USER_NAME_TEST,
-            self::USER_EMAIL_TEST,
-            self::USER_PASSWORD_TEST,
-            self::USER_PHONE_TEST,
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PASSWORD_TEST,
+            ConstHelper::USER_PHONE_TEST,
         );
         $user = new User(
-            self::USER_NAME_TEST,
-            self::USER_EMAIL_TEST,
-            self::USER_PASSWORD_TEST,
-            self::USER_PHONE_TEST,
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PASSWORD_TEST,
+            ConstHelper::USER_PHONE_TEST,
         );
 
         $userRepository = $this->createMock(UserRepository::class);
@@ -209,9 +207,9 @@ class UserServiceTest extends TestCase
     {
         $userCreate = new UserEditableDto(
             "",
-            self::USER_EMAIL_TEST,
-            self::USER_PASSWORD_TEST,
-            self::USER_PHONE_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PASSWORD_TEST,
+            ConstHelper::USER_PHONE_TEST,
         );
 
         $userRepository = $this->createMock(UserRepository::class);
@@ -225,10 +223,10 @@ class UserServiceTest extends TestCase
     public function testCreateUserEmptyEmail(): void
     {
         $userCreate = new UserEditableDto(
-            self::USER_NAME_TEST,
+            ConstHelper::USER_NAME_TEST,
             "",
-            self::USER_PASSWORD_TEST,
-            self::USER_PHONE_TEST,
+            ConstHelper::USER_PASSWORD_TEST,
+            ConstHelper::USER_PHONE_TEST,
         );
 
         $userRepository = $this->createMock(UserRepository::class);
@@ -242,10 +240,10 @@ class UserServiceTest extends TestCase
     public function testCreateUserEmptyPassword(): void
     {
         $userCreate = new UserEditableDto(
-            self::USER_NAME_TEST,
-            self::USER_EMAIL_TEST,
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
             "",
-            self::USER_PHONE_TEST,
+            ConstHelper::USER_PHONE_TEST,
         );
 
         $userRepository = $this->createMock(UserRepository::class);
@@ -259,16 +257,16 @@ class UserServiceTest extends TestCase
     public function testCreateUserRepositorySaveError(): void
     {
         $userCreate = new UserEditableDto(
-            self::USER_NAME_TEST,
-            self::USER_EMAIL_TEST,
-            self::USER_PASSWORD_TEST,
-            self::USER_PHONE_TEST,
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PASSWORD_TEST,
+            ConstHelper::USER_PHONE_TEST,
         );
         $user = new User(
-            self::USER_NAME_TEST,
-            self::USER_EMAIL_TEST,
-            self::USER_PASSWORD_TEST,
-            self::USER_PHONE_TEST,
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PASSWORD_TEST,
+            ConstHelper::USER_PHONE_TEST,
         );
 
         $userRepository = $this->createMock(UserRepository::class);
@@ -287,16 +285,16 @@ class UserServiceTest extends TestCase
     {
         $userId = 1;
         $userCreate = new UserEditableDto(
-            self::USER_NAME_TEST,
-            self::USER_EMAIL_TEST,
-            self::USER_PASSWORD_TEST,
-            self::USER_PHONE_TEST,
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PASSWORD_TEST,
+            ConstHelper::USER_PHONE_TEST,
         );
         $user = new User(
-            self::USER_NAME_TEST,
-            self::USER_EMAIL_TEST,
-            self::USER_PASSWORD_TEST,
-            self::USER_PHONE_TEST,
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PASSWORD_TEST,
+            ConstHelper::USER_PHONE_TEST,
         );
 
         $userRepository = $this->createMock(UserRepository::class);
@@ -319,9 +317,9 @@ class UserServiceTest extends TestCase
         $userId = 1;
         $userCreate = new UserEditableDto(
             "",
-            self::USER_EMAIL_TEST,
-            self::USER_PASSWORD_TEST,
-            self::USER_PHONE_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PASSWORD_TEST,
+            ConstHelper::USER_PHONE_TEST,
         );
 
         $userRepository = $this->createMock(UserRepository::class);
@@ -336,10 +334,10 @@ class UserServiceTest extends TestCase
     {
         $userId = 1;
         $userCreate = new UserEditableDto(
-            self::USER_NAME_TEST,
+            ConstHelper::USER_NAME_TEST,
             "",
-            self::USER_PASSWORD_TEST,
-            self::USER_PHONE_TEST,
+            ConstHelper::USER_PASSWORD_TEST,
+            ConstHelper::USER_PHONE_TEST,
         );
 
         $userRepository = $this->createMock(UserRepository::class);
@@ -354,10 +352,10 @@ class UserServiceTest extends TestCase
     {
         $userId = 1;
         $userCreate = new UserEditableDto(
-            self::USER_NAME_TEST,
-            self::USER_EMAIL_TEST,
-            self::USER_PASSWORD_TEST,
-            self::USER_PHONE_TEST,
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PASSWORD_TEST,
+            ConstHelper::USER_PHONE_TEST,
         );
 
         $userRepository = $this->createMock(UserRepository::class);
@@ -376,10 +374,10 @@ class UserServiceTest extends TestCase
     {
         $userId = 1;
         $userCreate = new UserEditableDto(
-            self::USER_NAME_TEST,
-            self::USER_EMAIL_TEST,
-            self::USER_PASSWORD_TEST,
-            self::USER_PHONE_TEST,
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PASSWORD_TEST,
+            ConstHelper::USER_PHONE_TEST,
         );
 
         $userRepository = $this->createMock(UserRepository::class);
@@ -398,16 +396,16 @@ class UserServiceTest extends TestCase
     {
         $userId = 1;
         $userCreate = new UserEditableDto(
-            self::USER_NAME_TEST,
-            self::USER_EMAIL_TEST,
-            self::USER_PASSWORD_TEST,
-            self::USER_PHONE_TEST,
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PASSWORD_TEST,
+            ConstHelper::USER_PHONE_TEST,
         );
         $user = new User(
-            self::USER_NAME_TEST,
-            self::USER_EMAIL_TEST,
-            self::USER_PASSWORD_TEST,
-            self::USER_PHONE_TEST,
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PASSWORD_TEST,
+            ConstHelper::USER_PHONE_TEST,
         );
 
         $userRepository = $this->createMock(UserRepository::class);

--- a/tests/Unit/Service/UserServiceTest.php
+++ b/tests/Unit/Service/UserServiceTest.php
@@ -2,6 +2,7 @@
 
 namespace App\Tests\Unit\Service;
 
+use App\Dto\UserDto;
 use App\Dto\UserEditableDto;
 use App\Entity\User;
 use App\Exception\InvalidRequestException;
@@ -17,13 +18,13 @@ class UserServiceTest extends TestCase
 {
     public function testFindUserSuccess(): void
     {
-        $userId = 1;
         $user = new User(
             ConstHelper::USER_NAME_TEST,
             ConstHelper::USER_EMAIL_TEST,
             ConstHelper::USER_PASSWORD_TEST,
             ConstHelper::USER_PHONE_TEST,
         );
+        $user->setId(ConstHelper::USER_ID_TEST);
         $userDto = UserMapper::entityToDto($user);
 
         $userRepository = $this->createMock(UserRepository::class);
@@ -33,15 +34,13 @@ class UserServiceTest extends TestCase
 
         $userService = new UserService($userRepository);
 
-        $response = $userService->findUser($userId);
+        $response = $userService->findUser(ConstHelper::USER_ID_TEST);
 
         $this->assertEquals($userDto, $response);
     }
 
     public function testFindUserNotFound(): void
     {
-        $userId = 1;
-
         $userRepository = $this->createMock(UserRepository::class);
         $userRepository->expects(self::once())
             ->method('find')
@@ -51,13 +50,11 @@ class UserServiceTest extends TestCase
 
         $this->expectException(UserNotFoundException::class);
 
-        $userService->findUser($userId);
+        $userService->findUser(ConstHelper::USER_ID_TEST);
     }
 
     public function testFindUserRepositoryError(): void
     {
-        $userId = 1;
-
         $userRepository = $this->createMock(UserRepository::class);
         $userRepository->expects(self::once())
             ->method('find')
@@ -67,7 +64,7 @@ class UserServiceTest extends TestCase
 
         $this->expectException(\Exception::class);
 
-        $userService->findUser($userId);
+        $userService->findUser(ConstHelper::USER_ID_TEST);
     }
 
     public function testFindAllUsersSuccess(): void
@@ -78,6 +75,7 @@ class UserServiceTest extends TestCase
             ConstHelper::USER_PASSWORD_TEST,
             ConstHelper::USER_PHONE_TEST,
         );
+        $user->setId(ConstHelper::USER_ID_TEST);
         $userDto = UserMapper::entityToDto($user);
 
         $userRepository = $this->createMock(UserRepository::class);
@@ -108,7 +106,6 @@ class UserServiceTest extends TestCase
 
     public function testRemoveUserSuccess(): void
     {
-        $userId = 1;
         $user = new User(
             ConstHelper::USER_NAME_TEST,
             ConstHelper::USER_EMAIL_TEST,
@@ -124,7 +121,7 @@ class UserServiceTest extends TestCase
             ->method('remove');
 
         $userService = new UserService($userRepository);
-        $userService->removeUser($userId);
+        $userService->removeUser(ConstHelper::USER_ID_TEST);
     }
 
     public function testRemoveUserRepositoryFindError(): void
@@ -191,6 +188,8 @@ class UserServiceTest extends TestCase
             ConstHelper::USER_PASSWORD_TEST,
             ConstHelper::USER_PHONE_TEST,
         );
+        $user->setId(ConstHelper::USER_ID_TEST);
+        $userDto = UserMapper::entityToDto($user);
 
         $userRepository = $this->createMock(UserRepository::class);
         $userRepository->expects(self::once())
@@ -201,7 +200,7 @@ class UserServiceTest extends TestCase
 
         $response = $userService->createUser($userCreate);
 
-        $this->assertEquals($user, $response);
+        $this->assertEquals($userDto, $response);
     }
 
     public function testCreateUserEmptyName(): void

--- a/tests/Unit/Service/UserServiceTest.php
+++ b/tests/Unit/Service/UserServiceTest.php
@@ -262,12 +262,6 @@ class UserServiceTest extends TestCase
             ConstHelper::USER_PASSWORD_TEST,
             ConstHelper::USER_PHONE_TEST,
         );
-        $user = new User(
-            ConstHelper::USER_NAME_TEST,
-            ConstHelper::USER_EMAIL_TEST,
-            ConstHelper::USER_PASSWORD_TEST,
-            ConstHelper::USER_PHONE_TEST,
-        );
 
         $userRepository = $this->createMock(UserRepository::class);
         $userRepository->expects(self::once())
@@ -283,7 +277,6 @@ class UserServiceTest extends TestCase
 
     public function testUpdateUserSuccess(): void
     {
-        $userId = 1;
         $userCreate = new UserEditableDto(
             ConstHelper::USER_NAME_TEST,
             ConstHelper::USER_EMAIL_TEST,
@@ -296,6 +289,8 @@ class UserServiceTest extends TestCase
             ConstHelper::USER_PASSWORD_TEST,
             ConstHelper::USER_PHONE_TEST,
         );
+        $user->setId(ConstHelper::USER_ID_TEST);
+        $userDto = UserMapper::entityToDto($user);
 
         $userRepository = $this->createMock(UserRepository::class);
         $userRepository->expects(self::once())
@@ -307,9 +302,12 @@ class UserServiceTest extends TestCase
 
         $userService = new UserService($userRepository);
 
-        $response = $userService->updateUser($userId, $userCreate);
+        $response = $userService->updateUser(ConstHelper::USER_ID_TEST, $userCreate);
 
-        $this->assertEquals($user, $response);
+        // Set current timestamp to update date
+        $userDto->setUpdatedAt($response->getUpdatedAt());
+
+        $this->assertEquals($userDto, $response);
     }
 
     public function testUpdateUserEmptyName(): void

--- a/tests/Unit/Service/UserServiceTest.php
+++ b/tests/Unit/Service/UserServiceTest.php
@@ -78,6 +78,7 @@ class UserServiceTest extends TestCase
             ConstHelper::USER_PASSWORD_TEST,
             ConstHelper::USER_PHONE_TEST,
         );
+        $userDto = UserMapper::entityToDto($user);
 
         $userRepository = $this->createMock(UserRepository::class);
         $userRepository->expects(self::once())
@@ -88,7 +89,7 @@ class UserServiceTest extends TestCase
 
         $response = $userService->findAllUsers();
 
-        $this->assertEquals([$user], $response);
+        $this->assertEquals([$userDto], $response);
     }
 
     public function testFindAllUsersRepositoryError(): void

--- a/tests/Utils/ConstHelper.php
+++ b/tests/Utils/ConstHelper.php
@@ -3,10 +3,12 @@
 namespace App\Tests\Utils;
 
 class ConstHelper {
+    const USER_ID_TEST = 1;
     const USER_NAME_TEST = "name";
     const USER_EMAIL_TEST = "email@domain.com";
     const USER_PASSWORD_TEST = "password";
     const USER_PHONE_TEST = "910123123";
+    const NEW_USER_ID_TEST = 2;
     const NEW_USER_NAME_TEST = "new name";
     const NEW_USER_EMAIL_TEST = "new_email@domain.com";
     const NEW_USER_PASSWORD_TEST = "new_password";


### PR DESCRIPTION
## Changes
* Add `UserDto` class.
* Update `findUser`, `findAllUsers`, `findUserByEmail`, `createUser`, `updateUser` service methods to return `UserDto`.
* Add `UserMapper` class with mapping support between entities and DTOs.
* Refactor `ConstHelper` constants across tests.
* Add `testSaveUserFailWithDuplicatedEmail` test.
* Update `openapi.yml` specs.