### PR TITLE
feat: add user password encoding

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "symfony/dotenv": "6.2.*",
         "symfony/flex": "^2",
         "symfony/framework-bundle": "6.2.*",
+        "symfony/password-hasher": "6.2.*",
         "symfony/property-access": "6.2.*",
         "symfony/runtime": "6.2.*",
         "symfony/serializer": "6.2.*",

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "symfony/password-hasher": "6.2.*",
         "symfony/property-access": "6.2.*",
         "symfony/runtime": "6.2.*",
+        "symfony/security-bundle": "6.2.*",
         "symfony/serializer": "6.2.*",
         "symfony/yaml": "6.2.*"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "92b7a4c95a5d9738c799aa21f6fa8224",
+    "content-hash": "ee87387341cd100d3dff0751488b012a",
     "packages": [
         {
             "name": "doctrine/cache",
@@ -3115,6 +3115,78 @@
                 }
             ],
             "time": "2023-02-01T08:32:25+00:00"
+        },
+        {
+            "name": "symfony/password-hasher",
+            "version": "v6.2.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/password-hasher.git",
+                "reference": "56aabf1c3f579c109b573d45a00a272d6abdfc81"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/password-hasher/zipball/56aabf1c3f579c109b573d45a00a272d6abdfc81",
+                "reference": "56aabf1c3f579c109b573d45a00a272d6abdfc81",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "conflict": {
+                "symfony/security-core": "<5.4"
+            },
+            "require-dev": {
+                "symfony/console": "^5.4|^6.0",
+                "symfony/security-core": "^5.4|^6.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\PasswordHasher\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Robin Chalas",
+                    "email": "robin.chalas@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides password hashing utilities",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "hashing",
+                "password"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/password-hasher/tree/v6.2.5"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-01-01T08:38:09+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ee87387341cd100d3dff0751488b012a",
+    "content-hash": "6c1b94584ca4c9a9815667d7cf0c5010",
     "packages": [
         {
             "name": "doctrine/cache",
@@ -3768,6 +3768,353 @@
                 }
             ],
             "time": "2023-01-20T17:45:48+00:00"
+        },
+        {
+            "name": "symfony/security-bundle",
+            "version": "v6.2.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/security-bundle.git",
+                "reference": "f3feb140c13015adecbeb51d49e45256aaf8a140"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/security-bundle/zipball/f3feb140c13015adecbeb51d49e45256aaf8a140",
+                "reference": "f3feb140c13015adecbeb51d49e45256aaf8a140",
+                "shasum": ""
+            },
+            "require": {
+                "composer-runtime-api": ">=2.1",
+                "ext-xml": "*",
+                "php": ">=8.1",
+                "symfony/config": "^6.1",
+                "symfony/dependency-injection": "^6.2",
+                "symfony/event-dispatcher": "^5.4|^6.0",
+                "symfony/http-foundation": "^6.2",
+                "symfony/http-kernel": "^6.2",
+                "symfony/password-hasher": "^5.4|^6.0",
+                "symfony/security-core": "^6.2",
+                "symfony/security-csrf": "^5.4|^6.0",
+                "symfony/security-http": "^6.2.6"
+            },
+            "conflict": {
+                "symfony/browser-kit": "<5.4",
+                "symfony/console": "<5.4",
+                "symfony/framework-bundle": "<5.4",
+                "symfony/ldap": "<5.4",
+                "symfony/twig-bundle": "<5.4"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^1.10.4|^2",
+                "symfony/asset": "^5.4|^6.0",
+                "symfony/browser-kit": "^5.4|^6.0",
+                "symfony/console": "^5.4|^6.0",
+                "symfony/css-selector": "^5.4|^6.0",
+                "symfony/dom-crawler": "^5.4|^6.0",
+                "symfony/expression-language": "^5.4|^6.0",
+                "symfony/form": "^5.4|^6.0",
+                "symfony/framework-bundle": "^5.4|^6.0",
+                "symfony/ldap": "^5.4|^6.0",
+                "symfony/process": "^5.4|^6.0",
+                "symfony/rate-limiter": "^5.4|^6.0",
+                "symfony/serializer": "^5.4|^6.0",
+                "symfony/translation": "^5.4|^6.0",
+                "symfony/twig-bridge": "^5.4|^6.0",
+                "symfony/twig-bundle": "^5.4|^6.0",
+                "symfony/validator": "^5.4|^6.0",
+                "symfony/yaml": "^5.4|^6.0",
+                "twig/twig": "^2.13|^3.0.4"
+            },
+            "type": "symfony-bundle",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Bundle\\SecurityBundle\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides a tight integration of the Security component into the Symfony full-stack framework",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/security-bundle/tree/v6.2.6"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-01-30T15:46:28+00:00"
+        },
+        {
+            "name": "symfony/security-core",
+            "version": "v6.2.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/security-core.git",
+                "reference": "3a26ddeda71fbbc6419578af526f4130cea3cc38"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/security-core/zipball/3a26ddeda71fbbc6419578af526f4130cea3cc38",
+                "reference": "3a26ddeda71fbbc6419578af526f4130cea3cc38",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/event-dispatcher-contracts": "^1.1|^2|^3",
+                "symfony/password-hasher": "^5.4|^6.0",
+                "symfony/service-contracts": "^1.1.6|^2|^3"
+            },
+            "conflict": {
+                "symfony/event-dispatcher": "<5.4",
+                "symfony/http-foundation": "<5.4",
+                "symfony/ldap": "<5.4",
+                "symfony/security-guard": "<5.4",
+                "symfony/validator": "<5.4"
+            },
+            "require-dev": {
+                "psr/cache": "^1.0|^2.0|^3.0",
+                "psr/container": "^1.1|^2.0",
+                "psr/log": "^1|^2|^3",
+                "symfony/cache": "^5.4|^6.0",
+                "symfony/event-dispatcher": "^5.4|^6.0",
+                "symfony/expression-language": "^5.4|^6.0",
+                "symfony/http-foundation": "^5.4|^6.0",
+                "symfony/ldap": "^5.4|^6.0",
+                "symfony/translation": "^5.4|^6.0",
+                "symfony/validator": "^5.4|^6.0"
+            },
+            "suggest": {
+                "psr/container-implementation": "To instantiate the Security class",
+                "symfony/event-dispatcher": "",
+                "symfony/expression-language": "For using the expression voter",
+                "symfony/http-foundation": "",
+                "symfony/ldap": "For using LDAP integration",
+                "symfony/validator": "For using the user password constraint"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Security\\Core\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Security Component - Core Library",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/security-core/tree/v6.2.5"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-01-24T13:16:10+00:00"
+        },
+        {
+            "name": "symfony/security-csrf",
+            "version": "v6.2.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/security-csrf.git",
+                "reference": "4abbe66efe965bec1dc0ea04b72c361971c4000d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/security-csrf/zipball/4abbe66efe965bec1dc0ea04b72c361971c4000d",
+                "reference": "4abbe66efe965bec1dc0ea04b72c361971c4000d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/security-core": "^5.4|^6.0"
+            },
+            "conflict": {
+                "symfony/http-foundation": "<5.4"
+            },
+            "require-dev": {
+                "symfony/http-foundation": "^5.4|^6.0"
+            },
+            "suggest": {
+                "symfony/http-foundation": "For using the class SessionTokenStorage."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Security\\Csrf\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Security Component - CSRF Library",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/security-csrf/tree/v6.2.5"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-01-20T18:25:26+00:00"
+        },
+        {
+            "name": "symfony/security-http",
+            "version": "v6.2.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/security-http.git",
+                "reference": "77c95eada3e3f0bf3a50f89817a18819b357376e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/security-http/zipball/77c95eada3e3f0bf3a50f89817a18819b357376e",
+                "reference": "77c95eada3e3f0bf3a50f89817a18819b357376e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.1|^3",
+                "symfony/http-foundation": "^5.4|^6.0",
+                "symfony/http-kernel": "^6.2",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/property-access": "^5.4|^6.0",
+                "symfony/security-core": "~6.0.19|~6.1.11|^6.2.5"
+            },
+            "conflict": {
+                "symfony/event-dispatcher": "<5.4.9|>=6,<6.0.9",
+                "symfony/security-bundle": "<5.4",
+                "symfony/security-csrf": "<5.4"
+            },
+            "require-dev": {
+                "psr/log": "^1|^2|^3",
+                "symfony/cache": "^5.4|^6.0",
+                "symfony/expression-language": "^5.4|^6.0",
+                "symfony/rate-limiter": "^5.4|^6.0",
+                "symfony/routing": "^5.4|^6.0",
+                "symfony/security-csrf": "^5.4|^6.0",
+                "symfony/translation": "^5.4|^6.0"
+            },
+            "suggest": {
+                "symfony/routing": "For using the HttpUtils class to create sub-requests, redirect the user, and match URLs",
+                "symfony/security-csrf": "For using tokens to protect authentication/logout attempts"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Security\\Http\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Security Component - HTTP Integration",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/security-http/tree/v6.2.6"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-01-30T15:46:28+00:00"
         },
         {
             "name": "symfony/serializer",

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -5,4 +5,5 @@ return [
     Doctrine\Bundle\DoctrineBundle\DoctrineBundle::class => ['all' => true],
     Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle::class => ['all' => true],
     DAMA\DoctrineTestBundle\DAMADoctrineTestBundle::class => ['test' => true],
+    Symfony\Bundle\SecurityBundle\SecurityBundle::class => ['all' => true],
 ];

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -1,0 +1,39 @@
+security:
+    # https://symfony.com/doc/current/security.html#registering-the-user-hashing-passwords
+    password_hashers:
+        Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface: 'auto'
+    # https://symfony.com/doc/current/security.html#loading-the-user-the-user-provider
+    providers:
+        users_in_memory: { memory: null }
+    firewalls:
+        dev:
+            pattern: ^/(_(profiler|wdt)|css|images|js)/
+            security: false
+        main:
+            lazy: true
+            provider: users_in_memory
+
+            # activate different ways to authenticate
+            # https://symfony.com/doc/current/security.html#the-firewall
+
+            # https://symfony.com/doc/current/security/impersonating_user.html
+            # switch_user: true
+
+    # Easy way to control access for large sections of your site
+    # Note: Only the *first* access control that matches will be used
+    access_control:
+        # - { path: ^/admin, roles: ROLE_ADMIN }
+        # - { path: ^/profile, roles: ROLE_USER }
+
+when@test:
+    security:
+        password_hashers:
+            # By default, password hashers are resource intensive and take time. This is
+            # important to generate secure password hashes. In tests however, secure hashes
+            # are not important, waste resources and increase test times. The following
+            # reduces the work factor to the lowest possible values.
+            Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface:
+                algorithm: auto
+                cost: 4 # Lowest possible value for bcrypt
+                time_cost: 3 # Lowest possible value for argon
+                memory_cost: 10 # Lowest possible value for argon

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -1,7 +1,13 @@
 security:
     # https://symfony.com/doc/current/security.html#registering-the-user-hashing-passwords
     password_hashers:
-        Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface: 'auto'
+        # auto hasher with default options for the User class (and children)
+        App\Entity\User: 'auto'
+
+        # auto hasher with custom options for all PasswordAuthenticatedUserInterface instances
+        Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface:
+            algorithm: 'auto'
+            cost:      15
     # https://symfony.com/doc/current/security.html#loading-the-user-the-user-provider
     providers:
         users_in_memory: { memory: null }

--- a/src/Common/Password.php
+++ b/src/Common/Password.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Common;
+
+use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactory;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasher;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
+
+/**
+ * Password holds common password methods to be used across packages.
+ */
+class Password {
+    /**
+     * autoUserHasher generates a UserPasswordHasher based on auto password hashing configs.
+     *
+     * @return UserPasswordHasherInterface
+     */
+    public static function autoUserHasher(): UserPasswordHasherInterface
+    {
+        $passwordHasherFactory = new PasswordHasherFactory([
+            PasswordAuthenticatedUserInterface::class => ['algorithm' => 'auto'],
+        ]);
+
+        return new UserPasswordHasher($passwordHasherFactory);
+    }
+}

--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -11,6 +11,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -149,10 +150,11 @@ class UserController extends AbstractController
      *
      * @param Request $request
      * @param SerializerInterface $serializer
+     * @param UserPasswordHasherInterface $passwordHasher
      * @return Response
      */
     #[Route('/users', name: 'createUser', methods: [Request::METHOD_POST])]
-    public function createUser(Request $request, SerializerInterface $serializer): Response
+    public function createUser(Request $request, SerializerInterface $serializer, UserPasswordHasherInterface $passwordHasher): Response
     {
         try {
             $userCreate = $serializer->deserialize($request->getContent(), UserEditableDto::class, JsonEncoder::FORMAT);
@@ -162,7 +164,7 @@ class UserController extends AbstractController
         }
 
         try {
-            $user = $this->userService->createUser($userCreate);
+            $user = $this->userService->createUser($userCreate, $passwordHasher);
         } catch (InvalidRequestException $e) {
             $errorResponse = ErrorMessage::generate($e, $serializer);
 

--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -3,6 +3,7 @@
 namespace App\Controller;
 
 use App\Common\ErrorMessage;
+use App\Common\Password;
 use App\Dto\UserEditableDto;
 use App\Exception\InvalidRequestException;
 use App\Exception\UserNotFoundException;
@@ -11,7 +12,6 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Attribute\AsController;
-use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -150,11 +150,10 @@ class UserController extends AbstractController
      *
      * @param Request $request
      * @param SerializerInterface $serializer
-     * @param UserPasswordHasherInterface $passwordHasher
      * @return Response
      */
     #[Route('/users', name: 'createUser', methods: [Request::METHOD_POST])]
-    public function createUser(Request $request, SerializerInterface $serializer, UserPasswordHasherInterface $passwordHasher): Response
+    public function createUser(Request $request, SerializerInterface $serializer): Response
     {
         try {
             $userCreate = $serializer->deserialize($request->getContent(), UserEditableDto::class, JsonEncoder::FORMAT);
@@ -164,7 +163,7 @@ class UserController extends AbstractController
         }
 
         try {
-            $user = $this->userService->createUser($userCreate, $passwordHasher);
+            $user = $this->userService->createUser($userCreate);
         } catch (InvalidRequestException $e) {
             $errorResponse = ErrorMessage::generate($e, $serializer);
 

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -4,13 +4,14 @@ namespace App\Entity;
 
 use App\Repository\UserRepository;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 
 /**
  * User entity class.
  */
 #[ORM\Table(name: 'users')]
 #[ORM\Entity(repositoryClass: UserRepository::class)]
-class User
+class User implements PasswordAuthenticatedUserInterface
 {
     /**
      * @var int|null

--- a/src/Service/UserService.php
+++ b/src/Service/UserService.php
@@ -2,6 +2,7 @@
 
 namespace App\Service;
 
+use App\Common\Password;
 use App\Dto\UserDto;
 use App\Dto\UserEditableDto;
 use App\Exception\InvalidRequestException;
@@ -85,11 +86,10 @@ class UserService implements UserServiceInterface {
 
     /**
      * @param UserEditableDto $userEditable
-     * @param UserPasswordHasherInterface $passwordHasher
      * @return UserDto
      * @throws InvalidRequestException
      */
-    public function createUser(UserEditableDto $userEditable, UserPasswordHasherInterface $passwordHasher): UserDto {
+    public function createUser(UserEditableDto $userEditable): UserDto {
         if($userEditable->getName() == "") {
             throw new InvalidRequestException(self::ERROR_EMPTY_USER_NAME);
         }
@@ -101,6 +101,8 @@ class UserService implements UserServiceInterface {
         }
 
         $user = UserMapper::userEditableDtoToEntity($userEditable);
+
+        $passwordHasher = Password::autoUserHasher();
 
         $hashedPassword = $passwordHasher->hashPassword($user, $user->getPassword());
         $user->setPassword($hashedPassword);
@@ -138,6 +140,11 @@ class UserService implements UserServiceInterface {
         if($userEditable->getPassword()!="") {
             $user->setPassword($userEditable->getPassword());
         }
+
+        $passwordHasher = Password::autoUserHasher();
+
+        $hashedPassword = $passwordHasher->hashPassword($user, $user->getPassword());
+        $user->setPassword($hashedPassword);
 
         $updatedUser = $this->userRepository->save($user, true);
 

--- a/src/Service/UserService.php
+++ b/src/Service/UserService.php
@@ -4,11 +4,11 @@ namespace App\Service;
 
 use App\Dto\UserDto;
 use App\Dto\UserEditableDto;
-use App\Entity\User;
 use App\Exception\InvalidRequestException;
 use App\Exception\UserNotFoundException;
 use App\Mapper\UserMapper;
 use App\Repository\UserRepositoryInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
 /**
  * UserService holds user service layer and parses data from controller into the repository layer.
@@ -85,10 +85,11 @@ class UserService implements UserServiceInterface {
 
     /**
      * @param UserEditableDto $userEditable
+     * @param UserPasswordHasherInterface $passwordHasher
      * @return UserDto
      * @throws InvalidRequestException
      */
-    public function createUser(UserEditableDto $userEditable): UserDto {
+    public function createUser(UserEditableDto $userEditable, UserPasswordHasherInterface $passwordHasher): UserDto {
         if($userEditable->getName() == "") {
             throw new InvalidRequestException(self::ERROR_EMPTY_USER_NAME);
         }
@@ -100,6 +101,9 @@ class UserService implements UserServiceInterface {
         }
 
         $user = UserMapper::userEditableDtoToEntity($userEditable);
+
+        $hashedPassword = $passwordHasher->hashPassword($user, $user->getPassword());
+        $user->setPassword($hashedPassword);
 
         $newUser = $this->userRepository->save($user, true);
 

--- a/src/Service/UserServiceInterface.php
+++ b/src/Service/UserServiceInterface.php
@@ -4,11 +4,11 @@ namespace App\Service;
 
 use App\Dto\UserDto;
 use App\Dto\UserEditableDto;
-use App\Entity\User;
 use App\Exception\InvalidRequestException;
 use App\Exception\UserNotFoundException;
 use App\Repository\UserRepositoryInterface;
 use Exception;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
 interface UserServiceInterface
 {
@@ -46,10 +46,11 @@ interface UserServiceInterface
 
     /**
      * @param UserEditableDto $userEditable
+     * @param UserPasswordHasherInterface $passwordHasher
      * @return UserDto
      * @throws Exception
      */
-    public function createUser(UserEditableDto $userEditable): UserDto;
+    public function createUser(UserEditableDto $userEditable, UserPasswordHasherInterface $passwordHasher): UserDto;
 
     /**
      * @throws InvalidRequestException

--- a/src/Service/UserServiceInterface.php
+++ b/src/Service/UserServiceInterface.php
@@ -50,7 +50,7 @@ interface UserServiceInterface
      * @return UserDto
      * @throws Exception
      */
-    public function createUser(UserEditableDto $userEditable, UserPasswordHasherInterface $passwordHasher): UserDto;
+    public function createUser(UserEditableDto $userEditable): UserDto;
 
     /**
      * @throws InvalidRequestException

--- a/symfony.lock
+++ b/symfony.lock
@@ -107,5 +107,17 @@
             "./config/packages/routing.yaml",
             "./config/routes.yaml"
         ]
+    },
+    "symfony/security-bundle": {
+        "version": "6.2",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "6.0",
+            "ref": "8a5b112826f7d3d5b07027f93786ae11a1c7de48"
+        },
+        "files": [
+            "./config/packages/security.yaml"
+        ]
     }
 }

--- a/tests/Integration/Controller/UserControllerTest.php
+++ b/tests/Integration/Controller/UserControllerTest.php
@@ -154,7 +154,7 @@ class UserControllerTest extends KernelTestCase
         $userService = new UserService($userRepository);
         $userController = new UserController($userService);
 
-        $response = $userController->removeUser($user->getId(), $this->serializer);
+        $response = $userController->removeUser($user->getId());
 
         $this->assertEquals(Response::HTTP_NO_CONTENT, $response->getStatusCode());
     }
@@ -374,7 +374,7 @@ class UserControllerTest extends KernelTestCase
     }
 
     public function testSaveUserFailWithDuplicatedEmail() {
-        $user = $this->addUser();
+        $this->addUser();
 
         $conflictingUser = new User(
             ConstHelper::USER_NAME_TEST,
@@ -425,7 +425,7 @@ class UserControllerTest extends KernelTestCase
         ;
     }
 
-    protected function createRequest(string $uri, string $method, string $content) {
+    protected function createRequest(string $uri, string $method, string $content): Request {
         return Request::create($uri, $method, [], [], [], [], $content);
     }
 }

--- a/tests/Integration/Service/UserServiceTest.php
+++ b/tests/Integration/Service/UserServiceTest.php
@@ -2,6 +2,7 @@
 
 namespace App\Tests\Integration\Service;
 
+use App\Common\Password;
 use App\Controller\UserController;
 use App\Dto\UserEditableDto;
 use App\Entity\User;
@@ -203,19 +204,17 @@ class UserServiceTest extends KernelTestCase
 
         $this->expectException(InvalidRequestException::class);
 
-        $response = $userService->updateUser($existingUser->getId(), $userCreate);
-
-        $this->removeUser($response);
+        $userService->updateUser($existingUser->getId(), $userCreate);
     }
 
     public function testUpdateUserNotFound(): void
     {
         $userId = 1;
         $userCreate = new UserEditableDto(
-            "new name",
-            "new_email@domain.com",
-            "new password",
-            "123",
+            ConstHelper::NEW_USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PASSWORD_TEST,
+            ConstHelper::USER_PHONE_TEST,
         );
 
         $userRepository = $this->entityManager->getRepository(User::class);

--- a/tests/Unit/Common/PasswordTest.php
+++ b/tests/Unit/Common/PasswordTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Tests\Unit\Common;
+
+use App\Common\Password;
+use App\Dto\ErrorDto;
+use App\Entity\User;
+use App\Tests\Utils\ConstHelper;
+use PHPUnit\Framework\TestCase;
+
+class PasswordTest extends TestCase{
+    public function testAutoUserHasherSuccess() {
+        $user = new User(
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PASSWORD_TEST,
+            ConstHelper::USER_PHONE_TEST
+        );
+
+        $hasher = Password::autoUserHasher();
+
+        $hashedPassword = $hasher->hashPassword($user, $user->getPassword());
+        $user->setPassword($hashedPassword);
+
+        $result = $hasher->isPasswordValid($user, ConstHelper::USER_PASSWORD_TEST);
+
+        $this->assertTrue($result);
+    }
+
+    public function testAutoUserHasherInvalid() {
+        $user = new User(
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PASSWORD_TEST,
+            ConstHelper::USER_PHONE_TEST
+        );
+
+        $hasher = Password::autoUserHasher();
+
+        $hashedPassword = $hasher->hashPassword($user, $user->getPassword());
+        $user->setPassword($hashedPassword);
+
+        $result = $hasher->isPasswordValid($user, ConstHelper::NEW_USER_PASSWORD_TEST);
+
+        $this->assertFalse($result);
+    }
+}

--- a/tests/Unit/Service/UserServiceTest.php
+++ b/tests/Unit/Service/UserServiceTest.php
@@ -2,6 +2,7 @@
 
 namespace App\Tests\Unit\Service;
 
+use App\Common\Password;
 use App\Dto\UserEditableDto;
 use App\Entity\User;
 use App\Exception\InvalidRequestException;


### PR DESCRIPTION
## Changes
* Add `symfony/security-bundle` dependency.
* Add `security.yaml` package configs.
* Add `symfony/password-hasher` dependency.
* Add `security.yaml` package configs.
* Add password hashing to `User` entity.
* Add common `Password` class with default user password hasher instantiation.
* Add password hasher to `createUser` and `updateUser` service methods.
* A `autoUserHasher` Password tests.