### PR TITLE
feat: add user roles

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,6 +72,7 @@
         "ext-pdo": "*",
         "dama/doctrine-test-bundle": "^7.2",
         "phpunit/php-code-coverage": "^10.0",
-        "phpunit/phpunit": "^10.0"
+        "phpunit/phpunit": "^10.0",
+        "symfony/maker-bundle": "^1.48"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "38a40b44e54eb65fca79250435cd46b1",
+    "content-hash": "d685e358faa09532d8d3abe3b7d5f997",
     "packages": [
         {
             "name": "doctrine/cache",
@@ -6306,6 +6306,99 @@
                 }
             ],
             "time": "2023-02-03T07:11:37+00:00"
+        },
+        {
+            "name": "symfony/maker-bundle",
+            "version": "v1.48.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/maker-bundle.git",
+                "reference": "2e428e8432e9879187672fe08f1cc335e2a31dd6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/maker-bundle/zipball/2e428e8432e9879187672fe08f1cc335e2a31dd6",
+                "reference": "2e428e8432e9879187672fe08f1cc335e2a31dd6",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/inflector": "^2.0",
+                "nikic/php-parser": "^4.11",
+                "php": ">=8.0",
+                "symfony/config": "^5.4.7|^6.0",
+                "symfony/console": "^5.4.7|^6.0",
+                "symfony/dependency-injection": "^5.4.7|^6.0",
+                "symfony/deprecation-contracts": "^2.2|^3",
+                "symfony/filesystem": "^5.4.7|^6.0",
+                "symfony/finder": "^5.4.3|^6.0",
+                "symfony/framework-bundle": "^5.4.7|^6.0",
+                "symfony/http-kernel": "^5.4.7|^6.0"
+            },
+            "conflict": {
+                "doctrine/doctrine-bundle": "<2.4",
+                "doctrine/orm": "<2.10",
+                "symfony/doctrine-bridge": "<5.4"
+            },
+            "require-dev": {
+                "composer/semver": "^3.0",
+                "doctrine/doctrine-bundle": "^2.4",
+                "doctrine/orm": "^2.10.0",
+                "symfony/http-client": "^5.4.7|^6.0",
+                "symfony/phpunit-bridge": "^5.4.7|^6.0",
+                "symfony/polyfill-php80": "^1.16.0",
+                "symfony/process": "^5.4.7|^6.0",
+                "symfony/security-core": "^5.4.7|^6.0",
+                "symfony/yaml": "^5.4.3|^6.0",
+                "twig/twig": "^2.0|^3.0"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Bundle\\MakerBundle\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Maker helps you create empty commands, controllers, form classes, tests and more so you can forget about writing boilerplate code.",
+            "homepage": "https://symfony.com/doc/current/bundles/SymfonyMakerBundle/index.html",
+            "keywords": [
+                "code generator",
+                "generator",
+                "scaffold",
+                "scaffolding"
+            ],
+            "support": {
+                "issues": "https://github.com/symfony/maker-bundle/issues",
+                "source": "https://github.com/symfony/maker-bundle/tree/v1.48.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-11-14T10:48:46+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -6,4 +6,5 @@ return [
     Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle::class => ['all' => true],
     DAMA\DoctrineTestBundle\DAMADoctrineTestBundle::class => ['test' => true],
     Symfony\Bundle\SecurityBundle\SecurityBundle::class => ['all' => true],
+    Symfony\Bundle\MakerBundle\MakerBundle::class => ['dev' => true],
 ];

--- a/migrations/Version20230206223110.php
+++ b/migrations/Version20230206223110.php
@@ -8,13 +8,13 @@ use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
 
 /**
- * Adds User entity table
+ * Adds User entity table.
  */
 final class Version20230206223110 extends AbstractMigration
 {
     public function getDescription(): string
     {
-        return 'Add User entity table';
+        return 'Add User entity table.';
     }
 
     public function up(Schema $schema): void

--- a/migrations/Version20230217175801.php
+++ b/migrations/Version20230217175801.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Adds User roles to database.
+ */
+final class Version20230217175801 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add User roles.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE users ADD roles JSON NOT NULL');
+    }
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE users DROP roles');
+    }
+}

--- a/src/Dto/UserDto.php
+++ b/src/Dto/UserDto.php
@@ -40,12 +40,18 @@ class UserDto
     private ?DateTimeInterface $updatedAt;
 
     /**
-     * @param int $int
+     * @var string[]
+     */
+    private array $roles;
+
+    /**
+     * @param int $id
      * @param string $name
      * @param string $email
      * @param string $phone
      * @param DateTimeInterface|null $createdAt
      * @param DateTimeInterface|null $updatedAt
+     * @param array $roles
      */
     public function __construct(
         int                $id,
@@ -54,6 +60,7 @@ class UserDto
         string             $phone,
         ?DateTimeInterface $createdAt = null,
         ?DateTimeInterface $updatedAt = null,
+        array $roles = [],
     ) {
         $this->id = $id;
         $this->name = $name;
@@ -61,6 +68,7 @@ class UserDto
         $this->phone = $phone;
         $this->createdAt = $createdAt;
         $this->updatedAt = $updatedAt;
+        $this->roles = $roles;
     }
 
     /**
@@ -124,6 +132,21 @@ class UserDto
     }
 
     /**
+     * @return string[]
+     */
+    public function getRoles(): array {
+        return $this->roles;
+    }
+
+    /**
+     * @param array $roles
+     * @return void
+     */
+    public function setRoles(array $roles): void {
+        $this->roles = $roles;
+    }
+
+        /**
      * @return DateTimeInterface
      */
     public function getCreatedAt(): DateTimeInterface {

--- a/src/Dto/UserEditableDto.php
+++ b/src/Dto/UserEditableDto.php
@@ -28,16 +28,23 @@ class UserEditableDto
     private ?string $phone = null;
 
     /**
+     * @var array
+     */
+    private array $roles;
+
+    /**
      * @param string $name
      * @param string $email
      * @param string $password
      * @param string $phone
+     * @param array $roles
      */
-    public function __construct(string $name, string $email, string $password, string $phone) {
+    public function __construct(string $name, string $email, string $password, string $phone, array $roles = []) {
         $this->name = $name;
         $this->email = $email;
         $this->password = $password;
         $this->phone = $phone;
+        $this->roles = $roles;
     }
 
     /**
@@ -98,5 +105,20 @@ class UserEditableDto
      */
     public function setPassword(string $password): void {
         $this->password = $password;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getRoles(): array {
+        return $this->roles;
+    }
+
+    /**
+     * @param array $roles
+     * @return void
+     */
+    public function setRoles(array $roles): void {
+        $this->roles = $roles;
     }
 }

--- a/src/Entity/Roles.php
+++ b/src/Entity/Roles.php
@@ -8,4 +8,12 @@ namespace App\Entity;
 class Roles {
     const ROLE_USER = "ROLE_USER";
     const ROLE_ADMIN = "ROLE_ADMIN";
+
+    public static function isValid(string $role): bool {
+        if($role == self::ROLE_USER || $role == self::ROLE_ADMIN) {
+            return true;
+        }
+
+        return false;
+    }
 }

--- a/src/Entity/Roles.php
+++ b/src/Entity/Roles.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Entity;
+
+/**
+ * Roles class that holds existing role constants.
+ */
+class Roles {
+    const ROLE_USER = "ROLE_USER";
+    const ROLE_ADMIN = "ROLE_ADMIN";
+}

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -66,12 +66,19 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
      * @param string $email
      * @param string $password
      * @param string $phone
+     * @param array $roles
      */
-    public function __construct(string $name, string $email, string $password, string $phone) {
+    public function __construct(
+        string $name, string $email,
+        string $password,
+        string $phone,
+        array $roles = [Roles::ROLE_USER],
+    ) {
         $this->name = $name;
         $this->email = $email;
         $this->password = $password;
         $this->phone = $phone;
+        $this->roles = $roles;
 
         $this->createdAt = new \DateTime();
     }

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -5,13 +5,14 @@ namespace App\Entity;
 use App\Repository\UserRepository;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
  * User entity class.
  */
 #[ORM\Table(name: 'users')]
 #[ORM\Entity(repositoryClass: UserRepository::class)]
-class User implements PasswordAuthenticatedUserInterface
+class User implements UserInterface, PasswordAuthenticatedUserInterface
 {
     /**
      * @var int|null
@@ -56,6 +57,9 @@ class User implements PasswordAuthenticatedUserInterface
      */
     #[ORM\Column(length: 255)]
     private ?\DateTime $updatedAt = null;
+
+    #[ORM\Column(type: 'json')]
+    private array $roles = [];
 
     /**
      * @param string $name
@@ -187,5 +191,58 @@ class User implements PasswordAuthenticatedUserInterface
         }
 
         $this->updatedAt = $updatedAt;
+    }
+
+    /**
+     * @see UserInterface
+     */
+    public function getRoles(): array
+    {
+        $roles = $this->roles;
+        // guarantee every user at least has ROLE_USER
+        $roles[] = Roles::ROLE_USER;
+
+        return array_unique($roles);
+    }
+
+    /**
+     * @param array $roles
+     * @return $this
+     */
+    public function setRoles(array $roles): self
+    {
+        $this->roles = $roles;
+
+        return $this;
+    }
+
+    /**
+     * Returning a salt is only needed if you are not using a modern
+     * hashing algorithm (e.g. bcrypt or sodium) in your security.yaml.
+     *
+     * @see UserInterface
+     */
+    public function getSalt(): ?string
+    {
+        return null;
+    }
+
+    /**
+     * @see UserInterface
+     */
+    public function eraseCredentials()
+    {
+        // If you store any temporary, sensitive data on the user, clear it here
+        // $this->plainPassword = null;
+    }
+
+    /**
+     * The public representation of the user (e.g. a username, an email address, etc.)
+     *
+     * @see UserInterface
+     */
+    public function getUserIdentifier(): string
+    {
+        return $this->email;
     }
 }

--- a/src/Mapper/UserMapper.php
+++ b/src/Mapper/UserMapper.php
@@ -19,6 +19,7 @@ class UserMapper {
             $entity->getPhone(),
             $entity->getCreatedAt(),
             $entity->getUpdatedAt(),
+            $entity->getRoles(),
         );
     }
 
@@ -46,6 +47,7 @@ class UserMapper {
             $userEditableDto->getEmail(),
             $userEditableDto->getPassword(),
             $userEditableDto->getPhone(),
+            $userEditableDto->getRoles(),
         );
     }
 }

--- a/src/Service/UserService.php
+++ b/src/Service/UserService.php
@@ -134,6 +134,7 @@ class UserService implements UserServiceInterface {
         $user->setName($userEditable->getName());
         $user->setEmail($userEditable->getEmail());
         $user->setPhone($userEditable->getPhone());
+        $user->setRoles($userEditable->getRoles());
         $user->setUpdatedAt(new \DateTime());
 
         if($userEditable->getPassword()!="") {

--- a/symfony.lock
+++ b/symfony.lock
@@ -95,6 +95,15 @@
             "./src/Kernel.php"
         ]
     },
+    "symfony/maker-bundle": {
+        "version": "1.48",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "1.0",
+            "ref": "fadbfe33303a76e25cb63401050439aa9b1a9c7f"
+        }
+    },
     "symfony/routing": {
         "version": "6.2",
         "recipe": {

--- a/tests/Integration/Controller/UserControllerTest.php
+++ b/tests/Integration/Controller/UserControllerTest.php
@@ -213,6 +213,35 @@ class UserControllerTest extends KernelTestCase
         FixtureHelper::removeUser($this->entityManager, $newUser);
     }
 
+    public function testCreateUserSuccessWithRoles(): void
+    {
+        $userCreate = new UserEditableDto(
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PASSWORD_TEST,
+            ConstHelper::USER_PHONE_TEST,
+        );
+
+        $userRepository = $this->entityManager->getRepository(User::class);
+        $userService = new UserService($userRepository);
+        $userController = new UserController($userService, $this->serializer);
+
+        $content = $this->serializer->serialize($userCreate, JsonEncoder::FORMAT);
+        $request = RequestHelper::createRequest("/users", Request::METHOD_POST, $content);
+
+        $response = $userController->createUser($request);
+
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
+
+        // Fix: get user from response
+        $normalizedUser = json_decode($response->getContent(), true);
+        if($normalizedUser["id"] != null) {
+            $newUser = $userRepository->find($normalizedUser["id"]);
+        }
+
+        FixtureHelper::removeUser($this->entityManager, $newUser);
+    }
+
     public function testCreateUserEmptyName(): void
     {
         $userCreate = new UserEditableDto(

--- a/tests/Integration/Controller/UserControllerTest.php
+++ b/tests/Integration/Controller/UserControllerTest.php
@@ -366,8 +366,8 @@ class UserControllerTest extends KernelTestCase
 
         $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
 
+        // Check if roles were properly updated
         $existingUser = $userRepository->find($existingUser->getId());
-
         $this->assertEquals($expectedRoles, $existingUser->getRoles());
 
         FixtureHelper::removeUser($this->entityManager, $existingUser);

--- a/tests/Integration/Repository/UserRepositoryTest.php
+++ b/tests/Integration/Repository/UserRepositoryTest.php
@@ -2,10 +2,10 @@
 
 namespace App\Tests\Integration\Repository;
 
+use App\Entity\Roles;
 use App\Entity\User;
 use App\Tests\Utils\ConstHelper;
 use App\Tests\Utils\FixtureHelper;
-use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\ORM\EntityManager;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
@@ -49,6 +49,7 @@ class UserRepositoryTest extends KernelTestCase
         $this->assertSame($user->getEmail(), $response->getEmail());
         $this->assertSame($user->getPassword(), $response->getPassword());
         $this->assertSame($user->getPhone(), $response->getPhone());
+        $this->assertSame($user->getRoles(), $response->getRoles());
 
         FixtureHelper::removeUser($this->entityManager, $user);
     }
@@ -66,6 +67,7 @@ class UserRepositoryTest extends KernelTestCase
         $this->assertSame($user->getEmail(), $response->getEmail());
         $this->assertSame($user->getPassword(), $response->getPassword());
         $this->assertSame($user->getPhone(), $response->getPhone());
+        $this->assertSame($user->getRoles(), $response->getRoles());
 
         FixtureHelper::removeUser($this->entityManager, $user);
     }
@@ -82,16 +84,19 @@ class UserRepositoryTest extends KernelTestCase
         $this->assertSame($user->getEmail(), $response->getEmail());
         $this->assertSame($user->getPassword(), $response->getPassword());
         $this->assertSame($user->getPhone(), $response->getPhone());
+        $this->assertSame($user->getRoles(), $response->getRoles());
 
         FixtureHelper::removeUser($this->entityManager, $user);
     }
 
     public function testSaveUser() {
+        $expectedRoles = [Roles::ROLE_ADMIN, Roles::ROLE_USER];
         $user = new User(
             ConstHelper::USER_NAME_TEST,
             ConstHelper::USER_EMAIL_TEST,
             ConstHelper::USER_PASSWORD_TEST,
             ConstHelper::USER_PHONE_TEST,
+            $expectedRoles,
         );
         $timestamp = new \DateTime();
         $user->setCreatedAt($timestamp);
@@ -99,8 +104,7 @@ class UserRepositoryTest extends KernelTestCase
 
         $createdUser = $this->entityManager
             ->getRepository(User::class)
-            ->save($user, true)
-        ;
+            ->save($user, true);
 
         $this->assertSame($user->getName(), $createdUser->getName());
         $this->assertSame($user->getEmail(), $createdUser->getEmail());
@@ -108,6 +112,7 @@ class UserRepositoryTest extends KernelTestCase
         $this->assertSame($user->getPhone(), $createdUser->getPhone());
         $this->assertSame($timestamp, $createdUser->getCreatedAt());
         $this->assertSame($timestamp, $createdUser->getUpdatedAt());
+        $this->assertEquals($expectedRoles, $createdUser->getRoles());
 
         FixtureHelper::removeUser($this->entityManager, $createdUser);
     }

--- a/tests/Integration/Service/UserServiceTest.php
+++ b/tests/Integration/Service/UserServiceTest.php
@@ -3,6 +3,7 @@
 namespace App\Tests\Integration\Service;
 
 use App\Dto\UserEditableDto;
+use App\Entity\Roles;
 use App\Entity\User;
 use App\Exception\InvalidRequestException;
 use App\Exception\UserNotFoundException;
@@ -141,6 +142,29 @@ class UserServiceTest extends KernelTestCase
         $this->assertEquals($userCreate->getName(), $response->getName());
         $this->assertEquals($userCreate->getEmail(), $response->getEmail());
         $this->assertEquals($userCreate->getPhone(), $response->getPhone());
+        $this->assertEquals([Roles::ROLE_USER], $response->getRoles());
+    }
+
+    public function testCreateUserSuccessWithRoles(): void
+    {
+        $expectedRoles = [Roles::ROLE_USER, Roles::ROLE_ADMIN];
+        $userCreate = new UserEditableDto(
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PASSWORD_TEST,
+            ConstHelper::USER_PHONE_TEST,
+            $expectedRoles
+        );
+
+        $userRepository = $this->entityManager->getRepository(User::class);
+        $userService = new UserService($userRepository);
+
+        $response = $userService->createUser($userCreate);
+
+        $this->assertEquals($userCreate->getName(), $response->getName());
+        $this->assertEquals($userCreate->getEmail(), $response->getEmail());
+        $this->assertEquals($userCreate->getPhone(), $response->getPhone());
+        $this->assertEquals($expectedRoles, $response->getRoles());
     }
 
     public function testUpdateUserSuccess(): void
@@ -162,6 +186,33 @@ class UserServiceTest extends KernelTestCase
         $this->assertEquals($userCreate->getName(), $response->getName());
         $this->assertEquals($userCreate->getEmail(), $response->getEmail());
         $this->assertEquals($userCreate->getPhone(), $response->getPhone());
+        $this->assertEquals([Roles::ROLE_USER], $response->getRoles());
+
+        FixtureHelper::removeUser($this->entityManager, $existingUser);
+    }
+
+    public function testUpdateUserSuccessWithRoles(): void
+    {
+        $existingUser = FixtureHelper::addUser($this->entityManager);
+
+        $expectedRoles = [Roles::ROLE_USER, Roles::ROLE_ADMIN];
+        $userCreate = new UserEditableDto(
+            ConstHelper::NEW_USER_NAME_TEST,
+            ConstHelper::NEW_USER_EMAIL_TEST,
+            ConstHelper::NEW_USER_PASSWORD_TEST,
+            ConstHelper::NEW_USER_PHONE_TEST,
+            $expectedRoles
+        );
+
+        $userRepository = $this->entityManager->getRepository(User::class);
+        $userService = new UserService($userRepository);
+
+        $response = $userService->updateUser($existingUser->getId(), $userCreate);
+
+        $this->assertEquals($userCreate->getName(), $response->getName());
+        $this->assertEquals($userCreate->getEmail(), $response->getEmail());
+        $this->assertEquals($userCreate->getPhone(), $response->getPhone());
+        $this->assertEquals($expectedRoles, $response->getRoles());
 
         FixtureHelper::removeUser($this->entityManager, $existingUser);
     }

--- a/tests/Unit/Dto/UserDtoTest.php
+++ b/tests/Unit/Dto/UserDtoTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 class UserDtoTest extends TestCase{
     public function testUserDtoConstruct() {
         $timestamp = new \DateTime();
-        $expectedRoles = [Roles::ROLE_USER, Roles::ROLE_ADMIN];
+        $expectedRoles = [Roles::ROLE_USER];
 
         $user = new UserDto(
             ConstHelper::USER_ID_TEST,
@@ -19,6 +19,7 @@ class UserDtoTest extends TestCase{
             ConstHelper::USER_PHONE_TEST,
             $timestamp,
             $timestamp,
+            $expectedRoles,
         );
         $user->setId(ConstHelper::USER_ID_TEST);
 

--- a/tests/Unit/Dto/UserDtoTest.php
+++ b/tests/Unit/Dto/UserDtoTest.php
@@ -3,12 +3,14 @@
 namespace App\Tests\Unit\Dto;
 
 use App\DTO\UserDTO;
+use App\Entity\Roles;
 use App\Tests\Utils\ConstHelper;
 use PHPUnit\Framework\TestCase;
 
 class UserDtoTest extends TestCase{
     public function testUserDtoConstruct() {
         $timestamp = new \DateTime();
+        $expectedRoles = [Roles::ROLE_USER, Roles::ROLE_ADMIN];
 
         $user = new UserDto(
             ConstHelper::USER_ID_TEST,
@@ -27,6 +29,7 @@ class UserDtoTest extends TestCase{
         $this->assertEquals(ConstHelper::USER_PHONE_TEST, $user->getPhone());
         $this->assertEquals($timestamp, $user->getCreatedAt());
         $this->assertEquals($timestamp, $user->getUpdatedAt());
+        $this->assertEquals($expectedRoles, $user->getRoles());
     }
 
     public function testUserDtoId() {

--- a/tests/Unit/Dto/UserDtoTest.php
+++ b/tests/Unit/Dto/UserDtoTest.php
@@ -118,4 +118,19 @@ class UserDtoTest extends TestCase{
         $this->assertIsObject($user);
         $this->assertEquals($timestamp, $user->getUpdatedAt());
     }
+
+    public function testUserDtoRoles() {
+        $user = new UserDto(
+            ConstHelper::USER_ID_TEST,
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PHONE_TEST,
+        );
+        $expectedRoles = [Roles::ROLE_USER, Roles::ROLE_ADMIN];
+
+        $user->setRoles($expectedRoles);
+
+        $this->assertIsObject($user);
+        $this->assertEquals($expectedRoles, $user->getRoles());
+    }
 }

--- a/tests/Unit/Dto/UserEditableDtoTest.php
+++ b/tests/Unit/Dto/UserEditableDtoTest.php
@@ -98,4 +98,19 @@ class UserEditableDtoTest extends TestCase{
         $this->assertIsObject($user);
         $this->assertEquals(ConstHelper::NEW_USER_PHONE_TEST, $user->getPhone());
     }
+
+    public function testUserEditableDtoRoles() {
+        $user = new UserEditableDto(
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PASSWORD_TEST,
+            ConstHelper::USER_PHONE_TEST,
+        );
+        $expectedRoles = [Roles::ROLE_USER, Roles::ROLE_ADMIN];
+
+        $user->setRoles($expectedRoles);
+
+        $this->assertIsObject($user);
+        $this->assertEquals($expectedRoles, $user->getRoles());
+    }
 }

--- a/tests/Unit/Dto/UserEditableDtoTest.php
+++ b/tests/Unit/Dto/UserEditableDtoTest.php
@@ -3,11 +3,31 @@
 namespace App\Tests\Unit\Dto;
 
 use App\Dto\UserEditableDto;
+use App\Entity\Roles;
 use App\Tests\Utils\ConstHelper;
 use PHPUnit\Framework\TestCase;
 
 class UserEditableDtoTest extends TestCase{
     public function testUserEditableDtoConstruct() {
+        $expectedRoles = [Roles::ROLE_USER, Roles::ROLE_ADMIN];
+
+        $user = new UserEditableDto(
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PASSWORD_TEST,
+            ConstHelper::USER_PHONE_TEST,
+            $expectedRoles,
+        );
+
+        $this->assertIsObject($user);
+        $this->assertEquals(ConstHelper::USER_NAME_TEST, $user->getName());
+        $this->assertEquals(ConstHelper::USER_EMAIL_TEST, $user->getEmail());
+        $this->assertEquals(ConstHelper::USER_PASSWORD_TEST, $user->getPassword());
+        $this->assertEquals(ConstHelper::USER_PHONE_TEST, $user->getPhone());
+        $this->assertEquals($expectedRoles, $user->getRoles());
+    }
+
+    public function testUserEditableDtoConstructWithoutRoles() {
         $user = new UserEditableDto(
             ConstHelper::USER_NAME_TEST,
             ConstHelper::USER_EMAIL_TEST,
@@ -20,6 +40,7 @@ class UserEditableDtoTest extends TestCase{
         $this->assertEquals(ConstHelper::USER_EMAIL_TEST, $user->getEmail());
         $this->assertEquals(ConstHelper::USER_PASSWORD_TEST, $user->getPassword());
         $this->assertEquals(ConstHelper::USER_PHONE_TEST, $user->getPhone());
+        $this->assertEmpty($user->getRoles());
     }
 
     public function testUserEditableDtoName() {

--- a/tests/Unit/Entity/RolesTest.php
+++ b/tests/Unit/Entity/RolesTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Tests\Unit\Entity;
+
+use App\Entity\Roles;
+use PHPUnit\Framework\TestCase;
+
+class RolesTest extends TestCase
+{
+    public function testIsValidAdmin()
+    {
+        $response = Roles::isValid(Roles::ROLE_ADMIN);
+
+        $this->assertTrue($response);
+    }
+
+    public function testIsValidUser()
+    {
+        $response = Roles::isValid(Roles::ROLE_USER);
+
+        $this->assertTrue($response);
+    }
+    public function testIsValidFail()
+    {
+        $response = Roles::isValid("");
+
+        $this->assertFalse($response);
+    }
+}

--- a/tests/Unit/Entity/UserTest.php
+++ b/tests/Unit/Entity/UserTest.php
@@ -91,4 +91,16 @@ class UserTest extends TestCase{
 
         $this->assertEquals($roles, $user->getRoles());
     }
+
+    public function testUserGetSalt() {
+        $user = new User("", "", "", "");
+
+        $this->assertNull($user->getSalt());
+    }
+
+    public function testUserIdentifier() {
+        $user = new User("", ConstHelper::USER_EMAIL_TEST, "", "");
+
+        $this->assertEquals(ConstHelper::USER_EMAIL_TEST, $user->getUserIdentifier());
+    }
 }

--- a/tests/Unit/Entity/UserTest.php
+++ b/tests/Unit/Entity/UserTest.php
@@ -9,6 +9,27 @@ use PHPUnit\Framework\TestCase;
 
 class UserTest extends TestCase{
     public function testUserCreate() {
+        $expectedRoles = [Roles::ROLE_USER, Roles::ROLE_ADMIN];
+
+        $user = new User(
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PASSWORD_TEST,
+            ConstHelper::USER_PHONE_TEST,
+            $expectedRoles,
+        );
+
+        $this->assertIsObject($user);
+        $this->assertEquals(ConstHelper::USER_NAME_TEST, $user->getName());
+        $this->assertEquals(ConstHelper::USER_EMAIL_TEST, $user->getEmail());
+        $this->assertEquals(ConstHelper::USER_PASSWORD_TEST, $user->getPassword());
+        $this->assertEquals(ConstHelper::USER_PHONE_TEST, $user->getPhone());
+        $this->assertEquals($expectedRoles, $user->getRoles());
+    }
+
+    public function testUserCreateWithNoRoleSet() {
+        $expectedRoles = [Roles::ROLE_USER];
+
         $user = new User(
             ConstHelper::USER_NAME_TEST,
             ConstHelper::USER_EMAIL_TEST,
@@ -21,6 +42,7 @@ class UserTest extends TestCase{
         $this->assertEquals(ConstHelper::USER_EMAIL_TEST, $user->getEmail());
         $this->assertEquals(ConstHelper::USER_PASSWORD_TEST, $user->getPassword());
         $this->assertEquals(ConstHelper::USER_PHONE_TEST, $user->getPhone());
+        $this->assertEquals($expectedRoles, $user->getRoles());
     }
 
     public function testUserId() {

--- a/tests/Unit/Entity/UserTest.php
+++ b/tests/Unit/Entity/UserTest.php
@@ -2,6 +2,7 @@
 
 namespace App\Tests\Unit\Entity;
 
+use App\Entity\Roles;
 use App\Entity\User;
 use App\Tests\Utils\ConstHelper;
 use PHPUnit\Framework\TestCase;
@@ -79,5 +80,15 @@ class UserTest extends TestCase{
         $user->setUpdatedAt($updatedAt);
 
         $this->assertEquals($updatedAt, $user->getUpdatedAt());
+    }
+
+    public function testUserRoles() {
+        $user = new User("", "", "", "");
+
+        $roles = [Roles::ROLE_USER, Roles::ROLE_ADMIN];
+
+        $user->setRoles($roles);
+
+        $this->assertEquals($roles, $user->getRoles());
     }
 }

--- a/tests/Unit/Mapper/UserMapperTest.php
+++ b/tests/Unit/Mapper/UserMapperTest.php
@@ -32,6 +32,25 @@ class UserMapperTest extends TestCase{
         $this->assertEquals($expectedRoles, $dto->getRoles());
     }
 
+    public function testEntityToDtoWithoutRoles() {
+        $user = new User(
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PASSWORD_TEST,
+            ConstHelper::USER_PHONE_TEST,
+        );
+        $user->setId(ConstHelper::USER_ID_TEST);
+
+        $dto = UserMapper::entityToDto($user);
+
+        $this->assertEquals($user->getName(), $dto->getName());
+        $this->assertEquals($user->getEmail(), $dto->getEmail());
+        $this->assertEquals($user->getPhone(), $dto->getPhone());
+        $this->assertEquals($user->getCreatedAt(), $dto->getCreatedAt());
+        $this->assertEquals($user->getUpdatedAt(), $dto->getUpdatedAt());
+        $this->assertEquals([Roles::ROLE_USER], $dto->getRoles());
+    }
+
     public function testEntityToDtoArray() {
         $expectedRoles = [Roles::ROLE_USER, Roles::ROLE_ADMIN];
         $user = new User(
@@ -40,6 +59,27 @@ class UserMapperTest extends TestCase{
             ConstHelper::USER_PASSWORD_TEST,
             ConstHelper::USER_PHONE_TEST,
             $expectedRoles,
+        );
+        $user->setId(ConstHelper::USER_ID_TEST);
+        $users[] = $user;
+
+        $dto = UserMapper::entityToDtoArray($users);
+
+        $this->assertNotEmpty($dto);
+        $this->assertEquals($user->getName(), $dto[0]->getName());
+        $this->assertEquals($user->getEmail(), $dto[0]->getEmail());
+        $this->assertEquals($user->getPhone(), $dto[0]->getPhone());
+        $this->assertEquals($user->getCreatedAt(), $dto[0]->getCreatedAt());
+        $this->assertEquals($user->getUpdatedAt(), $dto[0]->getUpdatedAt());
+        $this->assertEquals($user->getRoles(), $dto[0]->getRoles());
+    }
+
+    public function testEntityToDtoArrayWithoutRoles() {
+        $user = new User(
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PASSWORD_TEST,
+            ConstHelper::USER_PHONE_TEST,
         );
         $user->setId(ConstHelper::USER_ID_TEST);
         $users[] = $user;
@@ -72,5 +112,22 @@ class UserMapperTest extends TestCase{
         $this->assertEquals($editableUser->getPassword(), $user->getPassword());
         $this->assertEquals($editableUser->getPhone(), $user->getPhone());
         $this->assertEquals($editableUser->getRoles(), $user->getRoles());
+    }
+
+    public function testUserEditableDtoToEntityWithoutRoles() {
+        $editableUser = new UserEditableDto(
+            ConstHelper::USER_NAME_TEST,
+            ConstHelper::USER_EMAIL_TEST,
+            ConstHelper::USER_PASSWORD_TEST,
+            ConstHelper::USER_PHONE_TEST,
+        );
+
+        $user = UserMapper::userEditableDtoToEntity($editableUser);
+
+        $this->assertEquals($editableUser->getName(), $user->getName());
+        $this->assertEquals($editableUser->getEmail(), $user->getEmail());
+        $this->assertEquals($editableUser->getPassword(), $user->getPassword());
+        $this->assertEquals($editableUser->getPhone(), $user->getPhone());
+        $this->assertEquals([Roles::ROLE_USER], $user->getRoles());
     }
 }

--- a/tests/Unit/Mapper/UserMapperTest.php
+++ b/tests/Unit/Mapper/UserMapperTest.php
@@ -8,7 +8,6 @@ use App\Entity\User;
 use App\Mapper\UserMapper;
 use App\Tests\Utils\ConstHelper;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Security\Core\Role\Role;
 
 class UserMapperTest extends TestCase{
     public function testEntityToDto() {

--- a/tests/Unit/Mapper/UserMapperTest.php
+++ b/tests/Unit/Mapper/UserMapperTest.php
@@ -3,18 +3,22 @@
 namespace App\Tests\Unit\Mapper;
 
 use App\Dto\UserEditableDto;
+use App\Entity\Roles;
 use App\Entity\User;
 use App\Mapper\UserMapper;
 use App\Tests\Utils\ConstHelper;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Role\Role;
 
 class UserMapperTest extends TestCase{
     public function testEntityToDto() {
+        $expectedRoles = [Roles::ROLE_USER, Roles::ROLE_ADMIN];
         $user = new User(
             ConstHelper::USER_NAME_TEST,
             ConstHelper::USER_EMAIL_TEST,
             ConstHelper::USER_PASSWORD_TEST,
             ConstHelper::USER_PHONE_TEST,
+            $expectedRoles,
         );
         $user->setId(ConstHelper::USER_ID_TEST);
 
@@ -25,14 +29,17 @@ class UserMapperTest extends TestCase{
         $this->assertEquals($user->getPhone(), $dto->getPhone());
         $this->assertEquals($user->getCreatedAt(), $dto->getCreatedAt());
         $this->assertEquals($user->getUpdatedAt(), $dto->getUpdatedAt());
+        $this->assertEquals($expectedRoles, $dto->getRoles());
     }
 
     public function testEntityToDtoArray() {
+        $expectedRoles = [Roles::ROLE_USER, Roles::ROLE_ADMIN];
         $user = new User(
             ConstHelper::USER_NAME_TEST,
             ConstHelper::USER_EMAIL_TEST,
             ConstHelper::USER_PASSWORD_TEST,
             ConstHelper::USER_PHONE_TEST,
+            $expectedRoles,
         );
         $user->setId(ConstHelper::USER_ID_TEST);
         $users[] = $user;
@@ -45,14 +52,17 @@ class UserMapperTest extends TestCase{
         $this->assertEquals($user->getPhone(), $dto[0]->getPhone());
         $this->assertEquals($user->getCreatedAt(), $dto[0]->getCreatedAt());
         $this->assertEquals($user->getUpdatedAt(), $dto[0]->getUpdatedAt());
+        $this->assertEquals($user->getRoles(), $dto[0]->getRoles());
     }
 
     public function testUserEditableDtoToEntity() {
+        $expectedRoles = [Roles::ROLE_USER, Roles::ROLE_ADMIN];
         $editableUser = new UserEditableDto(
             ConstHelper::USER_NAME_TEST,
             ConstHelper::USER_EMAIL_TEST,
             ConstHelper::USER_PASSWORD_TEST,
             ConstHelper::USER_PHONE_TEST,
+            $expectedRoles,
         );
 
         $user = UserMapper::userEditableDtoToEntity($editableUser);
@@ -61,5 +71,6 @@ class UserMapperTest extends TestCase{
         $this->assertEquals($editableUser->getEmail(), $user->getEmail());
         $this->assertEquals($editableUser->getPassword(), $user->getPassword());
         $this->assertEquals($editableUser->getPhone(), $user->getPhone());
+        $this->assertEquals($editableUser->getRoles(), $user->getRoles());
     }
 }

--- a/tests/Utils/FixtureHelper.php
+++ b/tests/Utils/FixtureHelper.php
@@ -3,6 +3,7 @@
 namespace App\Tests\Utils;
 
 use App\Common\Password;
+use App\Entity\Roles;
 use App\Entity\User;
 use Doctrine\ORM\EntityManager;
 
@@ -12,11 +13,14 @@ class FixtureHelper {
      * @return User|null
      */
     public static function addUser(EntityManager $entityManager): ?User {
+        $expectedRoles = [Roles::ROLE_USER, Roles::ROLE_ADMIN];
+
         $user = new User(
             ConstHelper::USER_NAME_TEST,
             ConstHelper::USER_EMAIL_TEST,
             ConstHelper::USER_PASSWORD_TEST,
             ConstHelper::USER_PHONE_TEST,
+            $expectedRoles,
         );
         $user->setCreatedAt(new \DateTime());
         $user->setUpdatedAt(new \DateTime());


### PR DESCRIPTION
## Changes
* Add user `Roles` class.
* Add `symfony/maker-bundle` dependency.
* Add user roles to database migrations.
* Add `roles` attribute to `User` entity.
* Add `UserInterface` to `User` entity and `roles` attribute.
* Add `UserInterface` to `User` entity with `getRoles`, `eraseCredentials` and `getUserIdentifier` methods.
* Add `roles` attribute to `UserDto` and `UserEditableDto`.
* Update `UserMapper` methods to map roles between entity and DTOs.
* Update `UserService` to map roles when updating rules.
* Update fixtures and tests to add/assert user roles.