### PR TITLE
feat: add uuid

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "symfony/runtime": "6.2.*",
         "symfony/security-bundle": "6.2.*",
         "symfony/serializer": "6.2.*",
+        "symfony/uid": "6.2.*",
         "symfony/yaml": "6.2.*"
     },
     "config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cb3bdf90e62f9889b094f042adf3c391",
+    "content-hash": "5a8a58392fbdb743f36b2423c982d4cd",
     "packages": [
         {
             "name": "doctrine/cache",
@@ -3702,6 +3702,88 @@
             "time": "2022-11-03T14:55:06+00:00"
         },
         {
+            "name": "symfony/polyfill-uuid",
+            "version": "v1.27.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-uuid.git",
+                "reference": "f3cf1a645c2734236ed1e2e671e273eeb3586166"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-uuid/zipball/f3cf1a645c2734236ed1e2e671e273eeb3586166",
+                "reference": "f3cf1a645c2734236ed1e2e671e273eeb3586166",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "provide": {
+                "ext-uuid": "*"
+            },
+            "suggest": {
+                "ext-uuid": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.27-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Uuid\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Grégoire Pineau",
+                    "email": "lyrixx@lyrixx.info"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for uuid functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "uuid"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-uuid/tree/v1.27.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-11-03T14:55:06+00:00"
+        },
+        {
             "name": "symfony/property-access",
             "version": "v6.2.5",
             "source": {
@@ -4698,6 +4780,80 @@
             ],
             "support": {
                 "source": "https://github.com/symfony/string/tree/v6.2.5"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-01-01T08:38:09+00:00"
+        },
+        {
+            "name": "symfony/uid",
+            "version": "v6.2.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/uid.git",
+                "reference": "8ace895bded57d6496638c9b2d3b788e05b7395b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/uid/zipball/8ace895bded57d6496638c9b2d3b788e05b7395b",
+                "reference": "8ace895bded57d6496638c9b2d3b788e05b7395b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/polyfill-uuid": "^1.15"
+            },
+            "require-dev": {
+                "symfony/console": "^5.4|^6.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Uid\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Grégoire Pineau",
+                    "email": "lyrixx@lyrixx.info"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an object-oriented API to generate and represent UIDs",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "UID",
+                "ulid",
+                "uuid"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/uid/tree/v6.2.5"
             },
             "funding": [
                 {

--- a/migrations/Version20230218004313.php
+++ b/migrations/Version20230218004313.php
@@ -6,6 +6,7 @@ namespace DoctrineMigrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
+use Symfony\Bridge\Doctrine\Types\UuidType;
 
 /**
  * Add Users external Id.
@@ -21,13 +22,13 @@ final class Version20230218004313 extends AbstractMigration
     {
         $table = $schema->getTable("users");
 
-        $table->addColumn("externalId", "string")->setNotnull(true);
+        $table->addColumn("external_id", UuidType::NAME);
     }
 
     public function down(Schema $schema): void
     {
         $table = $schema->getTable("users");
 
-        $table->dropColumn("externalId");
+        $table->dropColumn("external_id");
     }
 }

--- a/migrations/Version20230218004313.php
+++ b/migrations/Version20230218004313.php
@@ -8,25 +8,26 @@ use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
 
 /**
- * Adds User roles to database.
+ * Add Users external Id.
  */
-final class Version20230217175801 extends AbstractMigration
+final class Version20230218004313 extends AbstractMigration
 {
     public function getDescription(): string
     {
-        return 'Add User roles.';
+        return 'Add Users external Id.';
     }
 
     public function up(Schema $schema): void
     {
         $table = $schema->getTable("users");
 
-        $table->addColumn("roles", "json");
+        $table->addColumn("externalId", "string")->setNotnull(true);
     }
+
     public function down(Schema $schema): void
     {
         $table = $schema->getTable("users");
 
-        $table->dropColumn("roles");
+        $table->dropColumn("externalId");
     }
 }

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -7,6 +7,7 @@ use Doctrine\ORM\Mapping as ORM;
 use Symfony\Bridge\Doctrine\Types\UuidType;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Uid\Uuid;
 
 /**
  * User entity class.
@@ -24,12 +25,12 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     private ?int $id = null;
 
     /**
-     * @var UuidType
+     * @var Uuid
      */
     #[ORM\Column(type: UuidType::NAME, unique: true)]
     #[ORM\GeneratedValue(strategy: 'CUSTOM')]
     #[ORM\CustomIdGenerator(class: 'doctrine.uuid_generator')]
-    private UuidType $externalId;
+    private Uuid $externalId;
 
     /**
      * @var string
@@ -105,6 +106,21 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
      */
     public function setId(int $id): void {
         $this->id = $id;
+    }
+
+    /**
+     * @return Uuid
+     */
+    public function getExternalId(): Uuid {
+        return $this->externalId;
+    }
+
+    /**
+     * @param Uuid $externalId
+     * @return void
+     */
+    public function setExternalId(Uuid $externalId): void {
+        $this->externalId = $externalId;
     }
 
     /**

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -4,6 +4,7 @@ namespace App\Entity;
 
 use App\Repository\UserRepository;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Bridge\Doctrine\Types\UuidType;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 
@@ -21,6 +22,14 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     #[ORM\GeneratedValue]
     #[ORM\Column]
     private ?int $id = null;
+
+    /**
+     * @var UuidType
+     */
+    #[ORM\Column(type: UuidType::NAME, unique: true)]
+    #[ORM\GeneratedValue(strategy: 'CUSTOM')]
+    #[ORM\CustomIdGenerator(class: 'doctrine.uuid_generator')]
+    private UuidType $externalId;
 
     /**
      * @var string

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -28,7 +28,6 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
      * @var Uuid
      */
     #[ORM\Column(type: UuidType::NAME, unique: true)]
-    #[ORM\GeneratedValue(strategy: 'CUSTOM')]
     #[ORM\CustomIdGenerator(class: 'doctrine.uuid_generator')]
     private Uuid $externalId;
 

--- a/src/Service/UserService.php
+++ b/src/Service/UserService.php
@@ -9,6 +9,7 @@ use App\Exception\InvalidRequestException;
 use App\Exception\UserNotFoundException;
 use App\Mapper\UserMapper;
 use App\Repository\UserRepositoryInterface;
+use Symfony\Component\Uid\Uuid;
 
 /**
  * UserService holds user service logic and maps data between controller and repository.
@@ -100,9 +101,9 @@ class UserService implements UserServiceInterface {
         }
 
         $user = UserMapper::userEditableDtoToEntity($userEditable);
+        $user->setExternalId(Uuid::v1());
 
         $passwordHasher = Password::autoUserHasher();
-
         $hashedPassword = $passwordHasher->hashPassword($user, $user->getPassword());
         $user->setPassword($hashedPassword);
 

--- a/symfony.lock
+++ b/symfony.lock
@@ -140,5 +140,17 @@
         "files": [
             "./config/packages/security.yaml"
         ]
+    },
+    "symfony/uid": {
+        "version": "6.2",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "6.2",
+            "ref": "d294ad4add3e15d7eb1bae0221588ca89b38e558"
+        },
+        "files": [
+            "./config/packages/uid.yaml"
+        ]
     }
 }

--- a/tests/Integration/Controller/UserControllerTest.php
+++ b/tests/Integration/Controller/UserControllerTest.php
@@ -471,7 +471,7 @@ class UserControllerTest extends KernelTestCase
         );
         $conflictingUser->setCreatedAt(new \DateTime());
         $conflictingUser->setUpdatedAt(new \DateTime());
-        $conflictingUser->setExternalId(new Uuid());
+        $conflictingUser->setExternalId(Uuid::v4());
 
         $this->expectException(UniqueConstraintViolationException::class);
 

--- a/tests/Integration/Controller/UserControllerTest.php
+++ b/tests/Integration/Controller/UserControllerTest.php
@@ -27,6 +27,7 @@ use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\Serializer\Serializer;
+use Symfony\Component\Uid\Uuid;
 
 class UserControllerTest extends KernelTestCase
 {
@@ -470,6 +471,7 @@ class UserControllerTest extends KernelTestCase
         );
         $conflictingUser->setCreatedAt(new \DateTime());
         $conflictingUser->setUpdatedAt(new \DateTime());
+        $conflictingUser->setExternalId(new Uuid());
 
         $this->expectException(UniqueConstraintViolationException::class);
 

--- a/tests/Integration/Repository/UserRepositoryTest.php
+++ b/tests/Integration/Repository/UserRepositoryTest.php
@@ -10,6 +10,7 @@ use Doctrine\ORM\EntityManager;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Uid\Uuid;
 
 class UserRepositoryTest extends KernelTestCase
 {
@@ -101,6 +102,7 @@ class UserRepositoryTest extends KernelTestCase
         $timestamp = new \DateTime();
         $user->setCreatedAt($timestamp);
         $user->setUpdatedAt($timestamp);
+        $user->setExternalId(Uuid::v4());
 
         $createdUser = $this->entityManager
             ->getRepository(User::class)

--- a/tests/Unit/Entity/UserTest.php
+++ b/tests/Unit/Entity/UserTest.php
@@ -6,6 +6,7 @@ use App\Entity\Roles;
 use App\Entity\User;
 use App\Tests\Utils\ConstHelper;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
 
 class UserTest extends TestCase{
     public function testUserCreate() {
@@ -51,6 +52,16 @@ class UserTest extends TestCase{
         $user->setId(ConstHelper::USER_ID_TEST);
 
         $this->assertEquals(ConstHelper::USER_ID_TEST, $user->getId());
+    }
+
+    public function testUserExternalId() {
+        $user = new User("", "", "", "");
+
+        $uuid = Uuid::v4();
+
+        $user->setExternalId($uuid);
+
+        $this->assertEquals($uuid, $user->getExternalId());
     }
 
     public function testUserName() {

--- a/tests/Utils/FixtureHelper.php
+++ b/tests/Utils/FixtureHelper.php
@@ -6,6 +6,7 @@ use App\Common\Password;
 use App\Entity\Roles;
 use App\Entity\User;
 use Doctrine\ORM\EntityManager;
+use Symfony\Component\Uid\Uuid;
 
 class FixtureHelper {
     /**
@@ -24,6 +25,7 @@ class FixtureHelper {
         );
         $user->setCreatedAt(new \DateTime());
         $user->setUpdatedAt(new \DateTime());
+        $user->setExternalId(Uuid::v4());
 
         $hasher = Password::autoUserHasher();
         $hashedPasswod = $hasher->hashPassword($user, ConstHelper::USER_PASSWORD_TEST);


### PR DESCRIPTION
## Changes
* Add `symfony/uid` dependency.
* Add user `externalId` with UUID type.
* Add `external_id` column to users database migration.
* Update user service `createUser` to generate uuids.
* Update tests and fixtures to generate uuid.
* Update entity tests assert `external_id` getters and setters.