### PR TITLE
feat: apply external id logic

### DIFF
--- a/migrations/Version20230217175801.php
+++ b/migrations/Version20230217175801.php
@@ -21,7 +21,7 @@ final class Version20230217175801 extends AbstractMigration
     {
         $table = $schema->getTable("users");
 
-        $table->addColumn("roles", "json");
+        $table->addColumn("roles", "json")->setDefault("[]");
     }
     public function down(Schema $schema): void
     {

--- a/migrations/Version20230218004313.php
+++ b/migrations/Version20230218004313.php
@@ -23,6 +23,7 @@ final class Version20230218004313 extends AbstractMigration
         $table = $schema->getTable("users");
 
         $table->addColumn("external_id", UuidType::NAME);
+        $table->addUniqueIndex(["external_id"]);
     }
 
     public function down(Schema $schema): void

--- a/openapi.yml
+++ b/openapi.yml
@@ -57,7 +57,8 @@ paths:
                 - in: path
                   name: userId
                   schema:
-                      type: integer
+                      type: string
+                      format: uuid
                   required: true
                   description: Numeric ID of a user
             responses:
@@ -82,7 +83,8 @@ paths:
                 - in: path
                   name: userId
                   schema:
-                      type: integer
+                      type: string
+                      format: uuid
                   required: true
                   description: Numeric ID of a user
             requestBody:
@@ -120,7 +122,8 @@ paths:
                 - in: path
                   name: userId
                   schema:
-                      type: integer
+                      type: string
+                      format: uuid
                   required: true
                   description: Numeric ID of a user.
             responses:
@@ -191,8 +194,8 @@ components:
             type: object
             properties:
                 id:
-                    type: integer
-                    format: int32
+                    type: string
+                    format: uuid
                 name:
                     type: string
                 email:

--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -15,6 +15,7 @@ use Symfony\Component\HttpKernel\Attribute\AsController;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Component\Uid\Uuid;
 
 /**
  * UserController holds user related controller methods and routing configs.
@@ -75,11 +76,11 @@ class UserController extends AbstractController
      * Returns a user, for a given user ID persisted users.
      * Returns a not found response if user doesn't exist.
      *
-     * @param int $userId
+     * @param Uuid $userId
      * @return Response
      */
     #[Route('/users/{userId}', name: 'singleUser', methods: [Request::METHOD_GET])]
-    public function singleUser(int $userId): Response
+    public function singleUser(Uuid $userId): Response
     {
         try {
             $user = $this->userService->findUser($userId);
@@ -134,11 +135,11 @@ class UserController extends AbstractController
      * Removes a user for a given user ID.
      * Returns user not found response if user doesn't exist.
      *
-     * @param int $userId
+     * @param Uuid $userId
      * @return Response
      */
     #[Route('/users/{userId}', name: 'removeUser', methods: [Request::METHOD_DELETE])]
-    public function removeUser(int $userId): Response
+    public function removeUser(Uuid $userId): Response
     {
         try {
             $this->userService->removeUser($userId);
@@ -192,12 +193,12 @@ class UserController extends AbstractController
      * Returns not found status if the user doesn't exist.
      * Returns bad request response when the user data isn't valid.
      *
-     * @param int $userId
+     * @param Uuid $userId
      * @param Request $request
      * @return Response
      */
     #[Route('/users/{userId}', name: 'updateUser', methods: [Request::METHOD_PUT])]
-    public function updateUser(int $userId, Request $request): Response
+    public function updateUser(Uuid $userId, Request $request): Response
     {
         try {
             $userCreate = $this->serializer->deserialize($request->getContent(), UserEditableDto::class, JsonEncoder::FORMAT);

--- a/src/Dto/UserDto.php
+++ b/src/Dto/UserDto.php
@@ -3,6 +3,7 @@
 namespace App\Dto;
 
 use DateTimeInterface;
+use Symfony\Component\Uid\Uuid;
 
 /**
  * UserDTO holds returnable data for a user.
@@ -10,9 +11,9 @@ use DateTimeInterface;
 class UserDto
 {
     /**
-     * @var int
+     * @var Uuid
      */
-    private int $id;
+    private Uuid $id;
 
     /**
      * @var string
@@ -45,7 +46,7 @@ class UserDto
     private array $roles;
 
     /**
-     * @param int $id
+     * @param Uuid $id
      * @param string $name
      * @param string $email
      * @param string $phone
@@ -54,7 +55,7 @@ class UserDto
      * @param array $roles
      */
     public function __construct(
-        int                $id,
+        Uuid               $id,
         string             $name,
         string             $email,
         string             $phone,
@@ -72,17 +73,17 @@ class UserDto
     }
 
     /**
-     * @return int
+     * @return Uuid
      */
-    public function getId(): int {
+    public function getId(): Uuid {
         return $this->id;
     }
 
     /**
-     * @param int $id
+     * @param Uuid $id
      * @return void
      */
-    public function setId(int $id): void {
+    public function setId(Uuid $id): void {
         $this->id = $id;
     }
 

--- a/src/Mapper/UserMapper.php
+++ b/src/Mapper/UserMapper.php
@@ -13,7 +13,7 @@ class UserMapper {
      */
     public static function entityToDto(User $entity): UserDto {
         return new UserDto(
-            $entity->getId(),
+            $entity->getExternalId(),
             $entity->getName(),
             $entity->getEmail(),
             $entity->getPhone(),

--- a/src/Service/UserService.php
+++ b/src/Service/UserService.php
@@ -33,12 +33,12 @@ class UserService implements UserServiceInterface {
     }
 
     /**
-     * @param int $userId
+     * @param Uuid $userId
      * @return UserDto
      * @throws UserNotFoundException
      */
-    public function findUser(int $userId): UserDto {
-        $user = $this->userRepository->find($userId);
+    public function findUser(Uuid $userId): UserDto {
+        $user = $this->userRepository->findOneBy(["external_id" => $userId]);
         if(empty($user)) {
             throw new UserNotFoundException($userId);
         }
@@ -71,12 +71,12 @@ class UserService implements UserServiceInterface {
     }
 
     /**
-     * @param int $userId
+     * @param Uuid $userId
      * @return void
      * @throws UserNotFoundException
      */
-    public function removeUser(int $userId): void {
-        $user = $this->userRepository->find($userId);
+    public function removeUser(Uuid $userId): void {
+        $user = $this->userRepository->findOneBy(["external_id" => $userId]);
         if(empty($user)) {
             throw new UserNotFoundException($userId);
         }
@@ -101,7 +101,7 @@ class UserService implements UserServiceInterface {
         }
 
         $user = UserMapper::userEditableDtoToEntity($userEditable);
-        $user->setExternalId(Uuid::v1());
+        $user->setExternalId(Uuid::v4());
 
         $passwordHasher = Password::autoUserHasher();
         $hashedPassword = $passwordHasher->hashPassword($user, $user->getPassword());
@@ -113,13 +113,14 @@ class UserService implements UserServiceInterface {
     }
 
     /**
-     * @param int $userId
+     * @param Uuid $userId
      * @param UserEditableDto $userEditable
      * @return UserDto
+     *
      * @throws InvalidRequestException
      * @throws UserNotFoundException
      */
-    public function updateUser(int $userId, UserEditableDto $userEditable): UserDto {
+    public function updateUser(Uuid $userId, UserEditableDto $userEditable): UserDto {
         if($userEditable->getName() == "") {
             throw new InvalidRequestException(self::ERROR_EMPTY_USER_NAME);
         }
@@ -127,7 +128,7 @@ class UserService implements UserServiceInterface {
             throw new InvalidRequestException(self::ERROR_EMPTY_USER_EMAIL);
         }
 
-        $user = $this->userRepository->find($userId);
+        $user = $this->userRepository->findOneBy(["external_id" => $userId]);
         if(empty($user)) {
             throw new UserNotFoundException($userId);
         }

--- a/src/Service/UserService.php
+++ b/src/Service/UserService.php
@@ -38,9 +38,9 @@ class UserService implements UserServiceInterface {
      * @throws UserNotFoundException
      */
     public function findUser(Uuid $userId): UserDto {
-        $user = $this->userRepository->findOneBy(["external_id" => $userId]);
+        $user = $this->userRepository->findOneBy(["externalId" => $userId]);
         if(empty($user)) {
-            throw new UserNotFoundException($userId);
+            throw new UserNotFoundException($userId->toRfc4122());
         }
 
         return UserMapper::entityToDto($user);
@@ -73,12 +73,13 @@ class UserService implements UserServiceInterface {
     /**
      * @param Uuid $userId
      * @return void
+     *
      * @throws UserNotFoundException
      */
     public function removeUser(Uuid $userId): void {
-        $user = $this->userRepository->findOneBy(["external_id" => $userId]);
+        $user = $this->userRepository->findOneBy(["externalId" => $userId]);
         if(empty($user)) {
-            throw new UserNotFoundException($userId);
+            throw new UserNotFoundException($userId->toRfc4122());
         }
 
         $this->userRepository->remove($user, true);
@@ -87,6 +88,7 @@ class UserService implements UserServiceInterface {
     /**
      * @param UserEditableDto $userEditable
      * @return UserDto
+     *
      * @throws InvalidRequestException
      */
     public function createUser(UserEditableDto $userEditable): UserDto {
@@ -128,9 +130,9 @@ class UserService implements UserServiceInterface {
             throw new InvalidRequestException(self::ERROR_EMPTY_USER_EMAIL);
         }
 
-        $user = $this->userRepository->findOneBy(["external_id" => $userId]);
+        $user = $this->userRepository->findOneBy(["externalId" => $userId]);
         if(empty($user)) {
-            throw new UserNotFoundException($userId);
+            throw new UserNotFoundException($userId->toRfc4122());
         }
 
         $user->setName($userEditable->getName());

--- a/src/Service/UserServiceInterface.php
+++ b/src/Service/UserServiceInterface.php
@@ -8,6 +8,7 @@ use App\Exception\InvalidRequestException;
 use App\Exception\UserNotFoundException;
 use App\Repository\UserRepositoryInterface;
 use Exception;
+use Symfony\Component\Uid\Uuid;
 
 interface UserServiceInterface
 {
@@ -18,11 +19,12 @@ interface UserServiceInterface
     public function __construct(UserRepositoryInterface $userRepository);
 
     /**
-     * @param int $userId
+     * @param Uuid $userId
      * @return UserDto
+     *
      * @throws UserNotFoundException
      */
-    public function findUser(int $userId): UserDto;
+    public function findUser(Uuid $userId): UserDto;
 
     /**
      * @return UserDto[]
@@ -32,28 +34,37 @@ interface UserServiceInterface
     /**
      * @param string $email
      * @return UserDto
+     *
      * @throws UserNotFoundException
      * @throws Exception
      */
     public function findUserByEmail(string $email): UserDto;
 
     /**
+     * @param Uuid $userId
+     * @return void
+     *
      * @throws UserNotFoundException
      * @throws Exception
      */
-    public function removeUser(int $userId): void;
+    public function removeUser(Uuid $userId): void;
 
     /**
      * @param UserEditableDto $userEditable
      * @return UserDto
+     *
      * @throws Exception
      */
     public function createUser(UserEditableDto $userEditable): UserDto;
 
     /**
+     * @param Uuid $userId
+     * @param UserEditableDto $userEditable
+     * @return UserDto
+     *
      * @throws InvalidRequestException
      * @throws UserNotFoundException
      * @throws Exception
      */
-    public function updateUser(int $userId, UserEditableDto $userEditable): UserDto;
+    public function updateUser(Uuid $userId, UserEditableDto $userEditable): UserDto;
 }

--- a/tests/Integration/Service/UserServiceTest.php
+++ b/tests/Integration/Service/UserServiceTest.php
@@ -15,6 +15,7 @@ use Doctrine\ORM\EntityManager;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Uid\Uuid;
 
 class UserServiceTest extends KernelTestCase
 {
@@ -22,6 +23,11 @@ class UserServiceTest extends KernelTestCase
      * @var EntityManager
      */
     private EntityManager $entityManager;
+
+    /**
+     * @var Uuid
+     */
+    private Uuid $userUuidTest;
 
     protected function setUp(): void
     {
@@ -38,6 +44,8 @@ class UserServiceTest extends KernelTestCase
         $commandTester->execute(['n']);
 
         $commandTester->assertCommandIsSuccessful();
+
+        $this->userUuidTest = Uuid::v4();
     }
 
     public function testListUsersSuccess(): void
@@ -63,7 +71,7 @@ class UserServiceTest extends KernelTestCase
         $userRepository = $this->entityManager->getRepository(User::class);
         $userService = new UserService($userRepository);
 
-        $response = $userService->findUser($user->getId());
+        $response = $userService->findUser($user->getExternalId());
 
         $this->assertEquals($userDto, $response);
 
@@ -77,7 +85,7 @@ class UserServiceTest extends KernelTestCase
 
         $this->expectException(UserNotFoundException::class);
 
-        $userService->findUser(ConstHelper::USER_ID_TEST);
+        $userService->findUser($this->userUuidTest);
     }
 
     public function testFindUserByEmailSuccess(): void
@@ -112,7 +120,7 @@ class UserServiceTest extends KernelTestCase
         $userRepository = $this->entityManager->getRepository(User::class);
         $userService = new UserService($userRepository);
 
-        $userService->removeUser($user->getId());
+        $userService->removeUser($user->getExternalId());
     }
 
     public function testRemoveUserNotFound(): void
@@ -122,7 +130,7 @@ class UserServiceTest extends KernelTestCase
 
         $this->expectException(UserNotFoundException::class);
 
-        $userService->removeUser(ConstHelper::USER_ID_TEST);
+        $userService->removeUser($this->userUuidTest);
     }
 
     public function testCreateUserSuccess(): void
@@ -181,7 +189,7 @@ class UserServiceTest extends KernelTestCase
         $userRepository = $this->entityManager->getRepository(User::class);
         $userService = new UserService($userRepository);
 
-        $response = $userService->updateUser($existingUser->getId(), $userCreate);
+        $response = $userService->updateUser($existingUser->getExternalId(), $userCreate);
 
         $this->assertEquals($userCreate->getName(), $response->getName());
         $this->assertEquals($userCreate->getEmail(), $response->getEmail());
@@ -207,7 +215,7 @@ class UserServiceTest extends KernelTestCase
         $userRepository = $this->entityManager->getRepository(User::class);
         $userService = new UserService($userRepository);
 
-        $response = $userService->updateUser($existingUser->getId(), $userCreate);
+        $response = $userService->updateUser($existingUser->getExternalId(), $userCreate);
 
         $this->assertEquals($userCreate->getName(), $response->getName());
         $this->assertEquals($userCreate->getEmail(), $response->getEmail());
@@ -233,7 +241,7 @@ class UserServiceTest extends KernelTestCase
 
         $this->expectException(InvalidRequestException::class);
 
-        $userService->updateUser($existingUser->getId(), $userCreate);
+        $userService->updateUser($existingUser->getExternalId(), $userCreate);
 
         FixtureHelper::removeUser($this->entityManager, $existingUser);
     }
@@ -254,7 +262,7 @@ class UserServiceTest extends KernelTestCase
 
         $this->expectException(InvalidRequestException::class);
 
-        $userService->updateUser($existingUser->getId(), $userCreate);
+        $userService->updateUser($existingUser->getExternalId(), $userCreate);
 
         FixtureHelper::removeUser($this->entityManager, $existingUser);
     }
@@ -273,7 +281,7 @@ class UserServiceTest extends KernelTestCase
 
         $this->expectException(UserNotFoundException::class);
 
-        $userService->updateUser(ConstHelper::USER_ID_TEST, $userCreate);
+        $userService->updateUser($this->userUuidTest, $userCreate);
     }
 
     protected function tearDown(): void

--- a/tests/Unit/Controller/AuthenticationControllerTest.php
+++ b/tests/Unit/Controller/AuthenticationControllerTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\Serializer\Serializer;
+use Symfony\Component\Uid\Uuid;
 
 class AuthenticationControllerTest extends TestCase
 {
@@ -43,8 +44,9 @@ class AuthenticationControllerTest extends TestCase
 
     public function testLoginSuccess(): void
     {
+        $userUuid = Uuid::v4();
         $userDto = new UserDto(
-            ConstHelper::USER_ID_TEST,
+            $userUuid,
             ConstHelper::USER_NAME_TEST,
             ConstHelper::USER_EMAIL_TEST,
             ConstHelper::USER_PHONE_TEST,

--- a/tests/Unit/Dto/UserDtoTest.php
+++ b/tests/Unit/Dto/UserDtoTest.php
@@ -6,14 +6,16 @@ use App\DTO\UserDTO;
 use App\Entity\Roles;
 use App\Tests\Utils\ConstHelper;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
 
 class UserDtoTest extends TestCase{
     public function testUserDtoConstruct() {
+        $userUuid = Uuid::v4();
         $timestamp = new \DateTime();
         $expectedRoles = [Roles::ROLE_USER];
 
         $user = new UserDto(
-            ConstHelper::USER_ID_TEST,
+            $userUuid,
             ConstHelper::USER_NAME_TEST,
             ConstHelper::USER_EMAIL_TEST,
             ConstHelper::USER_PHONE_TEST,
@@ -21,10 +23,10 @@ class UserDtoTest extends TestCase{
             $timestamp,
             $expectedRoles,
         );
-        $user->setId(ConstHelper::USER_ID_TEST);
+        $user->setId($userUuid);
 
         $this->assertIsObject($user);
-        $this->assertEquals(ConstHelper::USER_ID_TEST, $user->getId());
+        $this->assertEquals($userUuid, $user->getId());
         $this->assertEquals(ConstHelper::USER_NAME_TEST, $user->getName());
         $this->assertEquals(ConstHelper::USER_EMAIL_TEST, $user->getEmail());
         $this->assertEquals(ConstHelper::USER_PHONE_TEST, $user->getPhone());
@@ -34,22 +36,25 @@ class UserDtoTest extends TestCase{
     }
 
     public function testUserDtoId() {
+        $userUuid = Uuid::v4();
+        $newUserUuid = Uuid::v4();
         $user = new UserDto(
-            ConstHelper::USER_ID_TEST,
+            $userUuid,
             ConstHelper::USER_NAME_TEST,
             ConstHelper::USER_EMAIL_TEST,
             ConstHelper::USER_PHONE_TEST,
         );
 
-        $user->setId(ConstHelper::NEW_USER_ID_TEST);
+        $user->setId($newUserUuid);
 
         $this->assertIsObject($user);
-        $this->assertEquals(ConstHelper::NEW_USER_ID_TEST, $user->getId());
+        $this->assertEquals($newUserUuid, $user->getId());
     }
 
     public function testUserDtoName() {
+        $userUuid = Uuid::v4();
         $user = new UserDto(
-            ConstHelper::USER_ID_TEST,
+            $userUuid,
             ConstHelper::USER_NAME_TEST,
             ConstHelper::USER_EMAIL_TEST,
             ConstHelper::USER_PHONE_TEST,
@@ -62,8 +67,9 @@ class UserDtoTest extends TestCase{
     }
 
     public function testUserDtoEmail() {
+        $userUuid = Uuid::v4();
         $user = new UserDto(
-            ConstHelper::USER_ID_TEST,
+            $userUuid,
             ConstHelper::USER_NAME_TEST,
             ConstHelper::USER_EMAIL_TEST,
             ConstHelper::USER_PHONE_TEST,
@@ -76,8 +82,9 @@ class UserDtoTest extends TestCase{
     }
 
     public function testUserDtoPhone() {
+        $userUuid = Uuid::v4();
         $user = new UserDto(
-            ConstHelper::USER_ID_TEST,
+            $userUuid,
             ConstHelper::USER_NAME_TEST,
             ConstHelper::USER_EMAIL_TEST,
             ConstHelper::USER_PHONE_TEST,
@@ -90,8 +97,9 @@ class UserDtoTest extends TestCase{
     }
 
     public function testUserDtoCreatedAt() {
+        $userUuid = Uuid::v4();
         $user = new UserDto(
-            ConstHelper::USER_ID_TEST,
+            $userUuid,
             ConstHelper::USER_NAME_TEST,
             ConstHelper::USER_EMAIL_TEST,
             ConstHelper::USER_PHONE_TEST,
@@ -105,8 +113,9 @@ class UserDtoTest extends TestCase{
     }
 
     public function testUserDtoUpdatedAt() {
+        $userUuid = Uuid::v4();
         $user = new UserDto(
-            ConstHelper::USER_ID_TEST,
+            $userUuid,
             ConstHelper::USER_NAME_TEST,
             ConstHelper::USER_EMAIL_TEST,
             ConstHelper::USER_PHONE_TEST,
@@ -120,8 +129,9 @@ class UserDtoTest extends TestCase{
     }
 
     public function testUserDtoRoles() {
+        $userUuid = Uuid::v4();
         $user = new UserDto(
-            ConstHelper::USER_ID_TEST,
+            $userUuid,
             ConstHelper::USER_NAME_TEST,
             ConstHelper::USER_EMAIL_TEST,
             ConstHelper::USER_PHONE_TEST,

--- a/tests/Unit/Mapper/UserMapperTest.php
+++ b/tests/Unit/Mapper/UserMapperTest.php
@@ -8,9 +8,11 @@ use App\Entity\User;
 use App\Mapper\UserMapper;
 use App\Tests\Utils\ConstHelper;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
 
 class UserMapperTest extends TestCase{
     public function testEntityToDto() {
+        $userUuid = Uuid::v4();
         $expectedRoles = [Roles::ROLE_USER, Roles::ROLE_ADMIN];
         $user = new User(
             ConstHelper::USER_NAME_TEST,
@@ -19,7 +21,7 @@ class UserMapperTest extends TestCase{
             ConstHelper::USER_PHONE_TEST,
             $expectedRoles,
         );
-        $user->setId(ConstHelper::USER_ID_TEST);
+        $user->setExternalId($userUuid);
 
         $dto = UserMapper::entityToDto($user);
 
@@ -32,16 +34,18 @@ class UserMapperTest extends TestCase{
     }
 
     public function testEntityToDtoWithoutRoles() {
+        $userUuid = Uuid::v4();
         $user = new User(
             ConstHelper::USER_NAME_TEST,
             ConstHelper::USER_EMAIL_TEST,
             ConstHelper::USER_PASSWORD_TEST,
             ConstHelper::USER_PHONE_TEST,
         );
-        $user->setId(ConstHelper::USER_ID_TEST);
+        $user->setExternalId($userUuid);
 
         $dto = UserMapper::entityToDto($user);
 
+        $this->assertEquals($user->getExternalId(), $dto->getId());
         $this->assertEquals($user->getName(), $dto->getName());
         $this->assertEquals($user->getEmail(), $dto->getEmail());
         $this->assertEquals($user->getPhone(), $dto->getPhone());
@@ -51,6 +55,7 @@ class UserMapperTest extends TestCase{
     }
 
     public function testEntityToDtoArray() {
+        $userUuid = Uuid::v4();
         $expectedRoles = [Roles::ROLE_USER, Roles::ROLE_ADMIN];
         $user = new User(
             ConstHelper::USER_NAME_TEST,
@@ -59,12 +64,13 @@ class UserMapperTest extends TestCase{
             ConstHelper::USER_PHONE_TEST,
             $expectedRoles,
         );
-        $user->setId(ConstHelper::USER_ID_TEST);
+        $user->setExternalId($userUuid);
         $users[] = $user;
 
         $dto = UserMapper::entityToDtoArray($users);
 
         $this->assertNotEmpty($dto);
+        $this->assertEquals($user->getExternalId(), $dto[0]->getId());
         $this->assertEquals($user->getName(), $dto[0]->getName());
         $this->assertEquals($user->getEmail(), $dto[0]->getEmail());
         $this->assertEquals($user->getPhone(), $dto[0]->getPhone());
@@ -74,18 +80,20 @@ class UserMapperTest extends TestCase{
     }
 
     public function testEntityToDtoArrayWithoutRoles() {
+        $userUuid = Uuid::v4();
         $user = new User(
             ConstHelper::USER_NAME_TEST,
             ConstHelper::USER_EMAIL_TEST,
             ConstHelper::USER_PASSWORD_TEST,
             ConstHelper::USER_PHONE_TEST,
         );
-        $user->setId(ConstHelper::USER_ID_TEST);
+        $user->setExternalId($userUuid);
         $users[] = $user;
 
         $dto = UserMapper::entityToDtoArray($users);
 
         $this->assertNotEmpty($dto);
+        $this->assertEquals($user->getExternalId(), $dto[0]->getId());
         $this->assertEquals($user->getName(), $dto[0]->getName());
         $this->assertEquals($user->getEmail(), $dto[0]->getEmail());
         $this->assertEquals($user->getPhone(), $dto[0]->getPhone());

--- a/tests/Unit/Service/AuthenticationServiceTest.php
+++ b/tests/Unit/Service/AuthenticationServiceTest.php
@@ -11,11 +11,13 @@ use App\Repository\UserRepository;
 use App\Service\AuthenticationService;
 use App\Tests\Utils\ConstHelper;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
 
-class LoginServiceTest extends TestCase
+class AuthenticationServiceTest extends TestCase
 {
     public function testLoginSuccess(): void
     {
+        $userUuid = Uuid::v4();
         $loginDto = new LoginDto(
             ConstHelper::USER_EMAIL_TEST,
             ConstHelper::USER_PASSWORD_TEST,
@@ -26,7 +28,7 @@ class LoginServiceTest extends TestCase
             "",
             ConstHelper::USER_PHONE_TEST,
         );
-        $user->setId(ConstHelper::USER_ID_TEST);
+        $user->setExternalId($userUuid);
 
         $hasher = Password::autoUserHasher();
         $user->setPassword($hasher->hashPassword($user, ConstHelper::USER_PASSWORD_TEST));
@@ -47,6 +49,7 @@ class LoginServiceTest extends TestCase
 
     public function testLoginInvalidPassword(): void
     {
+        $userUuid = Uuid::v4();
         $loginDto = new LoginDto(
             ConstHelper::USER_EMAIL_TEST,
             ConstHelper::USER_PASSWORD_TEST,
@@ -57,7 +60,7 @@ class LoginServiceTest extends TestCase
             "",
             ConstHelper::USER_PHONE_TEST,
         );
-        $user->setId(ConstHelper::USER_ID_TEST);
+        $user->setExternalId($userUuid);
 
         $userRepository = $this->createMock(UserRepository::class);
         $userRepository->expects(self::once())

--- a/tests/Unit/Service/UserServiceTest.php
+++ b/tests/Unit/Service/UserServiceTest.php
@@ -12,69 +12,77 @@ use App\Service\UserService;
 use App\Tests\Utils\ConstHelper;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Uid\Uuid;
 
 class UserServiceTest extends TestCase
 {
     public function testFindUserSuccess(): void
     {
+        $userUuid = Uuid::v4();
         $user = new User(
             ConstHelper::USER_NAME_TEST,
             ConstHelper::USER_EMAIL_TEST,
             ConstHelper::USER_PASSWORD_TEST,
             ConstHelper::USER_PHONE_TEST,
         );
-        $user->setId(ConstHelper::USER_ID_TEST);
+        $user->setExternalId($userUuid);
         $userDto = UserMapper::entityToDto($user);
 
         $userRepository = $this->createMock(UserRepository::class);
         $userRepository->expects(self::once())
-            ->method('find')
+            ->method('findOneBy')
             ->willReturn($user);
 
         $userService = new UserService($userRepository);
 
-        $response = $userService->findUser(ConstHelper::USER_ID_TEST);
+        $response = $userService->findUser($userUuid);
 
         $this->assertEquals($userDto, $response);
     }
 
     public function testFindUserNotFound(): void
     {
+        $userUuid = Uuid::v4();
+
         $userRepository = $this->createMock(UserRepository::class);
         $userRepository->expects(self::once())
-            ->method('find')
+            ->method('findOneBy')
             ->willReturn(null);
 
         $userService = new UserService($userRepository);
 
         $this->expectException(UserNotFoundException::class);
 
-        $userService->findUser(ConstHelper::USER_ID_TEST);
+        $userService->findUser($userUuid);
     }
 
     public function testFindUserRepositoryError(): void
     {
+        $userUuid = Uuid::v4();
+
         $userRepository = $this->createMock(UserRepository::class);
         $userRepository->expects(self::once())
-            ->method('find')
+            ->method('findOneBy')
             ->willThrowException(new \Exception());
 
         $userService = new UserService($userRepository);
 
         $this->expectException(\Exception::class);
 
-        $userService->findUser(ConstHelper::USER_ID_TEST);
+        $userService->findUser($userUuid);
     }
 
     public function testFindAllUsersSuccess(): void
     {
+        $userUuid = Uuid::v4();
+
         $user = new User(
             ConstHelper::USER_NAME_TEST,
             ConstHelper::USER_EMAIL_TEST,
             ConstHelper::USER_PASSWORD_TEST,
             ConstHelper::USER_PHONE_TEST,
         );
-        $user->setId(ConstHelper::USER_ID_TEST);
+        $user->setExternalId($userUuid);
         $userDto = UserMapper::entityToDto($user);
 
         $userRepository = $this->createMock(UserRepository::class);
@@ -105,37 +113,40 @@ class UserServiceTest extends TestCase
 
     public function testRemoveUserSuccess(): void
     {
+        $userUuid = Uuid::v4();
         $user = new User(
             ConstHelper::USER_NAME_TEST,
             ConstHelper::USER_EMAIL_TEST,
             ConstHelper::USER_PASSWORD_TEST,
             ConstHelper::USER_PHONE_TEST,
         );
+        $user->setExternalId($userUuid);
 
         $userRepository = $this->createMock(UserRepository::class);
         $userRepository->expects(self::once())
-            ->method('find')
+            ->method('findOneBy')
             ->willReturn($user);
         $userRepository->expects(self::once())
             ->method('remove');
 
         $userService = new UserService($userRepository);
-        $userService->removeUser(ConstHelper::USER_ID_TEST);
+        $userService->removeUser($userUuid);
     }
 
     public function testRemoveUserRepositoryFindError(): void
     {
-        $userId = 1;
+        $userUuid = Uuid::v4();
         $user = new User(
             ConstHelper::USER_NAME_TEST,
             ConstHelper::USER_EMAIL_TEST,
             ConstHelper::USER_PASSWORD_TEST,
             ConstHelper::USER_PHONE_TEST,
         );
+        $user->setExternalId($userUuid);
 
         $userRepository = $this->createMock(UserRepository::class);
         $userRepository->expects(self::once())
-            ->method('find')
+            ->method('findOneBy')
             ->willReturn($user);
         $userRepository->expects(self::once())
             ->method('remove')
@@ -145,22 +156,23 @@ class UserServiceTest extends TestCase
 
         $this->expectException(\Exception::class);
 
-        $userService->removeUser($userId);
+        $userService->removeUser($userUuid);
     }
 
     public function testRemoveUserRepositoryRemoveError(): void
     {
-        $userId = 1;
+        $userUuid = Uuid::v4();
         $user = new User(
             ConstHelper::USER_NAME_TEST,
             ConstHelper::USER_EMAIL_TEST,
             ConstHelper::USER_PASSWORD_TEST,
             ConstHelper::USER_PHONE_TEST,
         );
+        $user->setExternalId($userUuid);
 
         $userRepository = $this->createMock(UserRepository::class);
         $userRepository->expects(self::once())
-            ->method('find')
+            ->method('findOneBy')
             ->willReturn($user);
         $userRepository->expects(self::once())
             ->method('remove')
@@ -170,11 +182,12 @@ class UserServiceTest extends TestCase
 
         $this->expectException(\Exception::class);
 
-        $userService->removeUser($userId);
+        $userService->removeUser($userUuid);
     }
 
     public function testCreateUserSuccess(): void
     {
+        $userUuid = Uuid::v4();
         $userCreate = new UserEditableDto(
             ConstHelper::USER_NAME_TEST,
             ConstHelper::USER_EMAIL_TEST,
@@ -187,7 +200,7 @@ class UserServiceTest extends TestCase
             ConstHelper::USER_PASSWORD_TEST,
             ConstHelper::USER_PHONE_TEST,
         );
-        $user->setId(ConstHelper::USER_ID_TEST);
+        $user->setExternalId($userUuid);
         $userDto = UserMapper::entityToDto($user);
 
         $userRepository = $this->createMock(UserRepository::class);
@@ -276,6 +289,7 @@ class UserServiceTest extends TestCase
 
     public function testUpdateUserSuccess(): void
     {
+        $externalUuid = Uuid::v4();
         $userCreate = new UserEditableDto(
             ConstHelper::USER_NAME_TEST,
             ConstHelper::USER_EMAIL_TEST,
@@ -288,12 +302,12 @@ class UserServiceTest extends TestCase
             ConstHelper::USER_PASSWORD_TEST,
             ConstHelper::USER_PHONE_TEST,
         );
-        $user->setId(ConstHelper::USER_ID_TEST);
+        $user->setExternalId($externalUuid);
         $userDto = UserMapper::entityToDto($user);
 
         $userRepository = $this->createMock(UserRepository::class);
         $userRepository->expects(self::once())
-            ->method('find')
+            ->method('findOneBy')
             ->willReturn($user);
         $userRepository->expects(self::once())
             ->method('save')
@@ -301,7 +315,7 @@ class UserServiceTest extends TestCase
 
         $userService = new UserService($userRepository);
 
-        $response = $userService->updateUser(ConstHelper::USER_ID_TEST, $userCreate);
+        $response = $userService->updateUser($externalUuid, $userCreate);
 
         // Set current timestamp to update date
         $userDto->setUpdatedAt($response->getUpdatedAt());
@@ -311,7 +325,7 @@ class UserServiceTest extends TestCase
 
     public function testUpdateUserEmptyName(): void
     {
-        $userId = 1;
+        $uuid = Uuid::v4();
         $userCreate = new UserEditableDto(
             "",
             ConstHelper::USER_EMAIL_TEST,
@@ -324,12 +338,12 @@ class UserServiceTest extends TestCase
 
         $this->expectException(InvalidRequestException::class);
 
-        $userService->updateUser($userId, $userCreate);
+        $userService->updateUser($uuid, $userCreate);
     }
 
     public function testUpdateUserEmptyEmail(): void
     {
-        $userId = 1;
+        $uuid = Uuid::v4();
         $userCreate = new UserEditableDto(
             ConstHelper::USER_NAME_TEST,
             "",
@@ -342,12 +356,12 @@ class UserServiceTest extends TestCase
 
         $this->expectException(InvalidRequestException::class);
 
-        $userService->updateUser($userId, $userCreate);
+        $userService->updateUser($uuid, $userCreate);
     }
 
     public function testUpdateUserNotFound(): void
     {
-        $userId = 1;
+        $userUuid = Uuid::v4();
         $userCreate = new UserEditableDto(
             ConstHelper::USER_NAME_TEST,
             ConstHelper::USER_EMAIL_TEST,
@@ -357,19 +371,19 @@ class UserServiceTest extends TestCase
 
         $userRepository = $this->createMock(UserRepository::class);
         $userRepository->expects(self::once())
-            ->method('find')
+            ->method('findOneBy')
             ->willReturn(null);
 
         $userService = new UserService($userRepository);
 
         $this->expectException(\Exception::class);
 
-        $userService->updateUser($userId, $userCreate);
+        $userService->updateUser($userUuid, $userCreate);
     }
 
     public function testUpdateUserRepositoryFindError(): void
     {
-        $userId = 1;
+        $uuid = Uuid::v4();
         $userCreate = new UserEditableDto(
             ConstHelper::USER_NAME_TEST,
             ConstHelper::USER_EMAIL_TEST,
@@ -379,19 +393,19 @@ class UserServiceTest extends TestCase
 
         $userRepository = $this->createMock(UserRepository::class);
         $userRepository->expects(self::once())
-            ->method('find')
+            ->method('findOneBy')
             ->willThrowException(new \Exception());
 
         $userService = new UserService($userRepository);
 
         $this->expectException(\Exception::class);
 
-        $userService->updateUser($userId, $userCreate);
+        $userService->updateUser($uuid, $userCreate);
     }
 
     public function testUpdateUserRepositorySaveError(): void
     {
-        $userId = 1;
+        $userUuid = Uuid::v4();
         $userCreate = new UserEditableDto(
             ConstHelper::USER_NAME_TEST,
             ConstHelper::USER_EMAIL_TEST,
@@ -404,10 +418,11 @@ class UserServiceTest extends TestCase
             ConstHelper::USER_PASSWORD_TEST,
             ConstHelper::USER_PHONE_TEST,
         );
+        $user->setExternalId($userUuid);
 
         $userRepository = $this->createMock(UserRepository::class);
         $userRepository->expects(self::once())
-            ->method('find')
+            ->method('findOneBy')
             ->willReturn($user);
         $userRepository->expects(self::once())
             ->method('save')
@@ -417,7 +432,7 @@ class UserServiceTest extends TestCase
 
         $this->expectException(\Exception::class);
 
-        $userService->updateUser($userId, $userCreate);
+        $userService->updateUser($userUuid, $userCreate);
     }
 
     protected function tearDown(): void


### PR DESCRIPTION
## Changes
* Refactor controller and service layer to use `externalId` logic.
* Update `openapi.yml` with `userId` uuid format.
* Fix unit and integration tests to support new `externalId` logic.
* Add unique `external_id` constraint to migrations.
* Set default `roles` column value in migrations.